### PR TITLE
Sentence lengths: more explicit and flexible config

### DIFF
--- a/morph/config.py
+++ b/morph/config.py
@@ -46,7 +46,8 @@ default = {
         # try playing fields in this order when using batch media player
     'batch media fields': [ u'Video', u'Sound' ],
         # configure morph man index algorithm
-    'optimal sentence length': 4,           # +1000 MMI per morpheme more/less than this after the first 2
+    'min good sentence length': 2,
+    'max good sentence length': 8,          # +1000 MMI per morpheme outside the "good" length range
     'reinforce new vocab weight': 5.0,      # -reinforce_weight / maturity MMI per known that is not yet mature
     'verb bonus': 100,                      # -verb_bonus if at least one unknown is a verb
     'priority.db weight': 200,              # -priority_weight per unknown that exists in priority.db

--- a/morph/main.py
+++ b/morph/main.py
@@ -220,9 +220,9 @@ def updateNotes( allDb ):
 
         usefulness = 999 - min( 999, usefulness )
 
-            # difference from optimal length (too little context vs long sentence)
-        lenDiff = max( 0, min( 9, abs( C('optimal sentence length') - N ) -2 ) )
-        tooLong = N > C('optimal sentence length')
+        # difference from optimal length range (too little context vs long sentence)
+        lenDiff = min(9, max(0, N - C('max good sentence length'), C('min good sentence length') - N))
+        tooLong = N > C('max good sentence length')
 
             # calculate mmi
         mmi = 10000*N_k + 1000*lenDiff + usefulness


### PR DESCRIPTION
Rather than name an "optimal" length L but treat all lengths [L-2,L+2]
as equally optimal, just name explicitly the min and max lengths for
that interval of equally-good lengths.

And fix the logic of the `mm_tooLong` tag to match how we prioritize
notes, only applying to notes we're actually penalizing for their
length rather than notes longer than the midpoint of the optimal
interval but which may still be within it.

Also widen the optimal interval somewhat by default,
from [2,6] to [2,8], because 6 morphemes is pretty short.