### PR TITLE
Provide separate options to set the various optional tags

### DIFF
--- a/morph/main.py
+++ b/morph/main.py
@@ -264,18 +264,16 @@ def updateNotes( allDb ):
 
             # other tags
         if priorityTag in ts:   ts.remove( priorityTag )
-        if isPriority:          ts.append( priorityTag )
+        if isPriority and jcfg('Option_SetTag_Priority'):
+            ts.append( priorityTag )
 
         if badLengthTag in ts:  ts.remove( badLengthTag )
-        if lenDiff:             ts.append( badLengthTag )
+        if lenDiff and jcfg('Option_SetTag_BadLength'):
+            ts.append( badLengthTag )
 
         if tooLongTag in ts:    ts.remove( tooLongTag )
-        if tooLong:             ts.append( tooLongTag )
-
-        # remove unnecessary tags
-        if not jcfg('Option_SetNotRequiredTags'):
-            unnecessary = [priorityTag, badLengthTag, tooLongTag]
-            ts = [tag for tag in ts if tag not in unnecessary]
+        if tooLong and jcfg('Option_SetTag_TooLong'):
+            ts.append( tooLongTag )
 
             # update sql db
         tags_ = TAG.join( TAG.canonify( ts ) )

--- a/morph/util.py
+++ b/morph/util.py
@@ -42,9 +42,7 @@ def initJcfg():
     mw.col.conf.setdefault(
             'addons', {}).setdefault(
                     'morphman', jcfg_default())
-
-    # this ensures forward compatibility, because it adds new options in configuration without any notice
-    jcfgAddMissing()
+    jcfgMigrate()
 
 addHook( 'profileLoaded', initCfg )
 addHook( 'profileLoaded', initJcfg )


### PR DESCRIPTION
I find the `mm_tooLong` and `mm_badLength` tags super noisy, because
they appear on tons of notes, so I appreciate the option to disable
them.  But I'd like to do so while still setting the `mm_priority`
tag, which by definition only appears on notes useful for a priority
morpheme, which isn't so common.

Here, provide separate toggles for the three optional tags.  For a
user with the omnibus `Option_SetNotRequiredTags` setting in their
config -- including any user running this version for the first time
after using the previous version of MorphMan -- we migrate that
setting to the three new settings, giving exactly the same behavior.

For new users without an existing config, set the default to silence
the two noisy tags while still setting `mm_priority`.

One harmless but confusing gotcha when testing this change: if you
disable a tag and recalculate, the tag may still exist on some notes
if you have the `only update k+2 and below` setting set (as I do.)
This is probably the right behavior, in keeping with the general point
of that setting.

The PreferencesDialog code gets a very small refactor to make
`self.boolOptionList` shared across all the frames/tabs of the
dialog.  I like how very generic and crisp the relevant logic in
`readConfigFromGui` is, and how this change doesn't have to touch
that method at all to introduce the new checkboxes.