### PR TITLE
Silence some noisy prints

### DIFF
--- a/morph/main.py
+++ b/morph/main.py
@@ -98,12 +98,12 @@ def mkAllDb( allDb=None ):
             else:
                 # mats changed -> new loc (new mats), move morphs
                 if loc.fieldValue == fieldValue and loc.maturities != mats:
-                    printf( '    .mats for %d[%s]' % ( nid, fieldName ) )
+                    #printf( '    .mats for %d[%s]' % ( nid, fieldName ) )
                     newLoc = AnkiDeck( nid, fieldName, fieldValue, guid, mats )
                     locDb[ newLoc ] = locDb.pop( loc )
                 # field changed -> new loc, new morphs
                 elif loc.fieldValue != fieldValue:
-                    printf( '    .morphs for %d[%s]' % ( nid, fieldName ) )
+                    #printf( '    .morphs for %d[%s]' % ( nid, fieldName ) )
                     newLoc = AnkiDeck( nid, fieldName, fieldValue, guid, mats )
                     ms = getMorphemes(morphemizer, fieldValue )
                     locDb.pop( loc )


### PR DESCRIPTION
These spit out a fair amount of noise each time I recalculate for the
day -- at least the `.mats` one does, because it's triggered by all
the cards I've reviewed.  They're debugging output that could be
useful in active development but are pure noise for a user; I had no
idea what they might be trying to tell me, up until just the other day
when I'd started trying some development on MorphMan and was looking
at this very piece of code.

So comment them out, just like the `.loc` print above them.
Alternatively it'd be pretty reasonable to delete them entirely.