### PR TITLE
Extend locations to optionally carry weights used in frequency

### DIFF
--- a/morph/main.py
+++ b/morph/main.py
@@ -159,10 +159,6 @@ def updateNotes( allDb ):
         knownDb.save( cfg1('path_known') )
         matureDb.save( cfg1('path_mature') )
 
-    mw.progress.update( label='Calculating frequency information' )
-    pops = [ len( locs ) for locs in allDb.db.values() ]
-    pops = [ n for n in pops if n > 1 ]
-
     mw.progress.update( label='Updating notes' )
     for i,( nid, mid, flds, guid, tags ) in enumerate( db.execute( 'select id, mid, flds, guid, tags from notes' ) ):
         if i % 500 == 0:    mw.progress.update( value=i )
@@ -198,7 +194,7 @@ def updateNotes( allDb ):
             # average frequency of unknowns (ie. how common the word is within your collection)
         F_k = 0
         for focusMorph in unknowns: # focusMorph used outside loop
-            F_k += len( allDb.db[ focusMorph ] )
+            F_k += allDb.frequency(focusMorph)
         F_k_avg = F_k // N_k if N_k > 0 else F_k
         usefulness = F_k_avg
 

--- a/morph/stats.py
+++ b/morph/stats.py
@@ -45,12 +45,13 @@ def updateStats( knownDb=None ):
         # track total unique morphemes + when weighted by frequency
         # NOTE: a morpheme may occur multiple times within the same sentence, but this frequency is wrt note fields
         numUniqueReq, numUniqueKnown, numFreqReq, numFreqKnown = 0, 0, 0, 0
-        for m,locs in gdb.db.iteritems():
+        for m in gdb.db.iterkeys():
+            freq = gdb.db.frequency(m)
             numUniqueReq += 1
-            numFreqReq   += len( locs )
+            numFreqReq   += freq
             if m in knownDb.db:
                 numUniqueKnown += 1
-                numFreqKnown   += len( locs )
+                numFreqKnown   += freq
         
         d['goals'][ name ] = { 'total':numUniqueReq, 'known':numUniqueKnown, 'freqTotal':numFreqReq, 'freqKnown':numFreqKnown }
 


### PR DESCRIPTION
This allows us to introduce external data that a given morpheme
is common, based on some external corpus, without needing to
record 1000 separate locations to get a frequency of 1000.

In looking for code that does the simple `len(locs)` frequency
count and should be updated to call the new function, found a
method that looks to be dead code (`popDb`) and a computation --
the "Calculating frequency information" step familiar from the
MorphMan recalc progress-bar dialog -- whose results are
apparently never used!  So cut both of those.

Also introduce a new Corpus location type, convenient for
this form of usage.