### PR TITLE
Remove `mm_badLength` tag, replace with `mm_tooShort`

### DIFF
--- a/morph/preferencesDialog.py
+++ b/morph/preferencesDialog.py
@@ -115,8 +115,8 @@ class PreferencesDialog( QDialog ):
                 ("Not ready:", 'Tag_NotReady', 'Note that has two or more unknown words.'),
                 ("Already known:", 'Tag_AlreadyKnown', 'You can add this tag to a note.\nAfter a recalc of the database, all in this sentence words are marked as known.\nPress \'K\' while reviewing to tag current card.'),
                 ("Priority:", 'Tag_Priority', 'Morpheme is in priority.db.'),
-                ("Bad Length:", 'Tag_BadLength', 'Sentence is too long or too short.'),
-                ("Too Long", 'Tag_TooLong', 'Sentence is too long.'),
+                ("Too Short:", 'Tag_TooShort', 'Sentence is too short.'),
+                ("Too Long:", 'Tag_TooLong', 'Sentence is too long.'),
             ]
         self.tagEntryList = []
         numberOfColumns = 2

--- a/morph/util.py
+++ b/morph/util.py
@@ -82,8 +82,8 @@ def jcfg_default():
         'Tag_NotReady':u'mm_notReady',             # set for k+2 and above cards
         'Tag_AlreadyKnown':u'mm_alreadyKnown',     # you can add this tag to a note to make anki treat it as if mature
         'Tag_Priority':u'mm_priority',             # set if note contains an unknown that exists in priority.db
-        'Tag_BadLength':u'mm_badLength',           # set if sentence isn't within optimal sentence length range
-        'Tag_TooLong':u'mm_tooLong',               # set if sentence is above optimal sentence length
+        'Tag_TooShort':u'mm_tooShort',             # set if sentence is below optimal length range
+        'Tag_TooLong':u'mm_tooLong',               # set if sentence is above optimal length range
 
         # filter for cards that should be analyzed, higher entries have higher priority
         'Filter': [


### PR DESCRIPTION
This makes the tags on too-short and too-long texts much more
symmetrical and easy to describe, and provides all the same
information to filter on.  It also gets rid of the "bad length" name,
which isn't particularly clear about what it means and sounds a lot
like an error message, in favor of the very straightforward
descriptions "too short" and "too long".