### PR TITLE
Convert usefulness to integer

### DIFF
--- a/morph/main.py
+++ b/morph/main.py
@@ -299,7 +299,7 @@ def updateNotes(allDb):
         lenDiff = min(9, abs(lenDiffRaw))
 
         # calculate mmi
-        mmi = 100000 * N_k + 1000 * lenDiff + usefulness
+        mmi = 100000 * N_k + 1000 * lenDiff + int(round(usefulness))
         if C('set due based on mmi'):
             nid2mmi[nid] = mmi
 


### PR DESCRIPTION
When specifying a float number in config.py 'frequency.txt weight scale' property, for example, 
0.5 as recomended in [MIA](https://massimmersionapproach.com/table-of-contents/anki/morphman/#frequency) website. Then the calculated **due** contains decimals.

This PR converts the usefulness to a rounded int before using it for the mmi.