### PR TITLE
Automatically use the length of frequency.txt to create a bonus

### DIFF
--- a/morph/config.py
+++ b/morph/config.py
@@ -80,10 +80,15 @@ default = {
     # -priority_weight per unknown that exists in priority.db
     'priority.db weight': 200,
 
-    # Scale by which card "due" values decrease per unknown in frequency.txt
-    # Lower the scale based on the size of frequency.txt
-    # Example: 10k frequency.txt scale: 2; 5k frequency.txt scale: 4
-    'frequency.txt weight scale': 10,
+    # NOTICE: this code has changed. Now the mm index is already factored by 10000 / frequency length
+    # If you came here to update this value to match your length of frequency.txt, then there is
+    # nothing to do, the MorphMan code does it automatically for you.
+    #'frequency.txt weight scale': 10,
+
+    # Maximum bonus a card can get by its position in frequency.txt.
+    # A card with an unknown morph that matches the first word in frequency.txt will get all this bonus.
+    # A card with an unknown morph that matches some of the last words in frequency.txt will get almost no bonus.
+    'frequency.txt bonus': 10000,
 
     # lite update
     # this reduces how many notes are changed and thus sync burden by not updating notes that aren't as important

--- a/morph/main.py
+++ b/morph/main.py
@@ -275,11 +275,11 @@ def updateNotes(allDb):
             try:
                 focusMorphIndex = frequency_list.index(focusMorphString)
                 isFrequency = True
-                frequencyWeight = C('frequency.txt weight scale')
+                frequencyBonus = C('frequency.txt bonus')
 
                 # The bigger this number, the lower mmi becomes
-                usefulness += (frequencyListLength -
-                               focusMorphIndex) * frequencyWeight
+                usefulness += int(round( frequencyBonus * (1 - focusMorphIndex / frequencyListLength) ))
+
             except ValueError:
                 pass
 
@@ -306,7 +306,7 @@ def updateNotes(allDb):
         lenDiff = min(9, abs(lenDiffRaw))
 
         # calculate mmi
-        mmi = 100000 * N_k + 1000 * lenDiff + int(round(usefulness))
+        mmi = 100000 * N_k + 1000 * lenDiff + usefulness
         if C('set due based on mmi'):
             nid2mmi[nid] = mmi
 


### PR DESCRIPTION
Use the already calculated frequencyListLength to simplify the use of a frequency.txt file.
With this PR there is no need to change config.py to match the length of the frequency.txt file.
