### PR TITLE
add travis config and pylint

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,14 @@
+language: python
+python:
+  - "3.6"
+  - "3.7"
+  - "3.8"
+install:
+  - pip install pylint
+  - pip install PyQt5
+  - wget https://github.com/dae/anki/archive/2.1.16.tar.gz
+  - tar -xzvf 2.1.16.tar.gz
+  - export PYTHONPATH=./anki-2.1.16
+script:
+  - python test.py
+  - pylint . morph test


### PR DESCRIPTION
Now that there are UnitTests we need to run them everytime. **Travis-CI** is the most commonly used CI and it's used by Anki itself. This PR contains a .travis.yml file to integrate with Travis-CI.
To take advantage of this, Travis must be configured by a repo admin. There is an example here https://travis-ci.org/davidgaya/MorphMan

What do you think ?