### PR TITLE
add pylint and fix or disable errors

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -1,0 +1,22 @@
+[MASTER]
+ignore=deps
+extension-pkg-whitelist=PyQt5
+
+[MESSAGES CONTROL]
+disable=C,R,
+  fixme,
+  unused-wildcard-import,
+  attribute-defined-outside-init,
+  redefined-builtin,
+  wildcard-import,
+  broad-except,
+  bare-except,
+  unused-argument,
+  unused-variable,
+  redefined-outer-name,
+  global-statement,
+  protected-access,
+  arguments-differ,
+
+[REPORTS]
+output-format=colorized

--- a/__init__.py
+++ b/__init__.py
@@ -68,6 +68,10 @@ def main():
     a.triggered.connect(onMorphManReadability)
     morphmanSubMenu.addAction(a)
 
+    # ToDo: remove this pylint disable. These imports are here because they have Anki
+    #   addHooks to initialize the UI. It would be better to initialize all Anki UI
+    #   in one single place with explicit call to reveal true intention.
+    # pylint: disable=W0611
     from .morph.browser import viewMorphemes
     from .morph.browser import extractMorphemes
     from .morph.browser import batchPlay

--- a/morph/browser/extractMorphemes.py
+++ b/morph/browser/extractMorphemes.py
@@ -2,7 +2,7 @@
 import os
 from anki.hooks import addHook
 from anki.utils import stripHTML
-from ..morphemes import AnkiDeck, MorphDb, getMorphemes, ms2str
+from ..morphemes import AnkiDeck, MorphDb, getMorphemes
 from ..morphemizer import getMorphemizerByName
 from ..util import addBrowserNoteSelectionCmd, mw, getFilter, infoMsg, QFileDialog
 from ..preferences import get_preference as cfg

--- a/morph/cli.py
+++ b/morph/cli.py
@@ -12,7 +12,7 @@ from .morphemizer import SpaceMorphemizer, MecabMorphemizer, CjkCharMorphemizer,
 
 # hack: typing is compile time anyway, so, nothing bad happens if it fails, the try is to support anki < 2.1.16
 try:
-    from aqt.pinnedmodules import typing
+    from aqt.pinnedmodules import typing  # pylint: disable=W0611 # See above hack comment
     from typing import Union, Optional
 except ImportError:
     pass

--- a/morph/manager.py
+++ b/morph/manager.py
@@ -142,14 +142,14 @@ class MorphMan(QDialog):
         self.analysisDisplay = QTextEdit()
 
         # Exporting
-        self.adaptiveSubs = mkBtn('Adaptive Subs', self.adaptiveSubs, vbox)
+        self.adaptiveSubs = mkBtn('Adaptive Subs', self.adaptiveSubsMethod, vbox)
 
         # layout
         grid.addLayout(vbox, 0, 0)
         grid.addWidget(self.morphDisplay, 0, 1)
         grid.addWidget(self.analysisDisplay, 0, 2)
 
-    def adaptiveSubs(self):
+    def adaptiveSubsMethod(self):
         self.hide()
         asw = AdaptiveSubWin(self.mw)
         asw.show()

--- a/morph/morphemes.py
+++ b/morph/morphemes.py
@@ -14,8 +14,8 @@ except:
 
 # hack: typing is compile time anyway, so, nothing bad happens if it fails, the try is to support anki < 2.1.16
 try:
-    from aqt.pinnedmodules import typing
-    from typing import Any, Dict, Set
+    from aqt.pinnedmodules import typing  # pylint: disable=W0611 # See above hack comment
+    from typing import Dict, Set
 except ImportError:
     pass
 
@@ -110,8 +110,6 @@ def ms2str(ms):  # [(Morpheme, locs)] -> Str
 
 
 class MorphDBUnpickler(pickle.Unpickler):
-    def __init__(self, file):
-        super(MorphDBUnpickler, self).__init__(file)
 
     def find_class(self, cmodule, cname):
         # Override default class lookup for this module to allow loading databases generated with older
@@ -400,7 +398,7 @@ class MorphDb:
     def locDb(self, recalc=True):  # Maybe Bool -> m Map Location {Morpheme}
         # type: (bool) ->  Dict[Location, Set[Morpheme]]
         if hasattr(self, '_locDb') and not recalc:
-            return self._locDb
+            return self._locDb  # pylint: disable=E0203 # pylint is wrong
         self._locDb = d = {}  # type: Dict[Location, Set[Morpheme]]
         for m, ls in self.db.items():
             for l in ls:
@@ -412,7 +410,7 @@ class MorphDb:
 
     def fidDb(self, recalc=True):  # Maybe Bool -> m Map FactId Location
         if hasattr(self, '_fidDb') and not recalc:
-            return self._fidDb
+            return self._fidDb  # pylint: disable=E0203 # pylint is wrong
         self._fidDb = d = {}
         for loc in self.locDb():
             try:

--- a/morph/newMorphHelper.py
+++ b/morph/newMorphHelper.py
@@ -1,9 +1,6 @@
 # -*- coding: utf-8 -*-
 import codecs
 
-# only for jedi-auto-completion
-from functools import partial
-
 import aqt.main
 
 from anki import sched, schedv2
@@ -98,8 +95,7 @@ def my_getNewCard(self, _old):
         if not C('next new card feature'):
             return _old(self)
         if not C('new card merged fill'):
-            card = _old(self)
-            ''' :type c: anki.cards.Card '''
+            card = _old(self)  # type: anki.cards.Card
         else:  # pop from opposite direction and skip sibling spacing
             if not self._fillNew():
                 return
@@ -245,7 +241,6 @@ def highlight(txt, extra, fieldDict, field, mod_field):
             frequency_list = [line.strip().split('\t')[0] for line in f.readlines()]
     except:
         frequency_list = []
-        pass  # User does not have a frequency.txt
 
     priority_db = main.MorphDb(cfg('path_priority'), ignoreErrors=True).db
     tags = fieldDict['Tags'].split()

--- a/morph/readability.py
+++ b/morph/readability.py
@@ -86,7 +86,7 @@ class CountingMorphDB:
         for alt, c in ms.items():
             if c[1]:  # Skip marked morphs
                 continue
-            if altIncludesMorpheme(alt, m):
+            if altIncludesMorpheme(alt, m):  # pylint: disable=W1114 #ToDo: verify if pylint is right
                 count += c[0]
         return count
 

--- a/morph/util.py
+++ b/morph/util.py
@@ -11,9 +11,10 @@ from aqt.qt import *
 from aqt.utils import showCritical, showInfo
 from .preferences import get_preference, init_preferences
 
+# hack: typing is compile time anyway, so, nothing bad happens if it fails, the try is to support anki < 2.1.16
 try:
-    from aqt.pinnedmodules import typing
-    from typing import Any, Dict, Set, List, Optional, Callable, TypeVar, Tuple
+    from aqt.pinnedmodules import typing  # pylint: disable=W0611 # See above hack comment
+    from typing import Any, Dict, List, Optional, Callable, TypeVar
 
     T = TypeVar('T')
 


### PR DESCRIPTION
This PR adds a PyLint configuration. The configuration has been copied and adapted from Anki's.

It fixes the following errors and warnings:

-------------------------------------------------------------------
************* Module MorphMan
__init__.py:71:4: W0611: Unused viewMorphemes imported from morph.browser (unused-import)
__init__.py:72:4: W0611: Unused extractMorphemes imported from morph.browser (unused-import)
__init__.py:73:4: W0611: Unused batchPlay imported from morph.browser (unused-import)
__init__.py:74:4: W0611: Unused massTagger imported from morph.browser (unused-import)
__init__.py:75:4: W0611: Unused learnNow imported from morph.browser (unused-import)
__init__.py:76:4: W0611: Unused browseMorph imported from morph.browser (unused-import)
__init__.py:77:4: W0611: Unused alreadyKnownTagger imported from morph.browser (unused-import)
__init__.py:78:4: W0611: Unused newMorphHelper imported from morph (unused-import)
__init__.py:79:4: W0611: Unused stats imported from morph (unused-import)
************* Module MorphMan.morph.manager
morph/manager.py:152:4: E0202: An attribute defined in MorphMan.morph.manager line 145 hides this method (method-hidden)
************* Module MorphMan.morph.main
morph/main.py:92:36: W0640: Cell variable mid defined in loop (cell-var-from-loop)
morph/main.py:147:29: W0631: Using possibly undefined loop variable 'i' (undefined-loop-variable)
morph/main.py:151:33: W0631: Using possibly undefined loop variable 'i' (undefined-loop-variable)
morph/main.py:201:8: W0107: Unnecessary pass statement (unnecessary-pass)
morph/main.py:227:36: W0640: Cell variable mid defined in loop (cell-var-from-loop)
morph/main.py:387:29: W0631: Using possibly undefined loop variable 'i' (undefined-loop-variable)
morph/main.py:392:29: W0631: Using possibly undefined loop variable 'i' (undefined-loop-variable)
morph/main.py:7:0: W0611: Unused partial imported from functools (unused-import)
morph/main.py:23:4: W0611: Unused typing imported from aqt.pinnedmodules (unused-import)
morph/main.py:24:4: W0611: Unused Any imported from typing (unused-import)
************* Module MorphMan.morph.cli
morph/cli.py:15:4: W0611: Unused typing imported from aqt.pinnedmodules (unused-import)
************* Module MorphMan.morph.morphemes
morph/morphemes.py:113:4: W0235: Useless super delegation in method '__init__' (useless-super-delegation)
morph/morphemes.py:403:19: E0203: Access to member '_locDb' before its definition line 404 (access-member-before-definition)
morph/morphemes.py:415:19: E0203: Access to member '_fidDb' before its definition line 416 (access-member-before-definition)
morph/morphemes.py:17:4: W0611: Unused typing imported from aqt.pinnedmodules (unused-import)
morph/morphemes.py:18:4: W0611: Unused Any imported from typing (unused-import)
************* Module MorphMan.morph.newMorphHelper
morph/newMorphHelper.py:102:12: W0105: String statement has no effect (pointless-string-statement)
morph/newMorphHelper.py:248:8: W0107: Unnecessary pass statement (unnecessary-pass)
morph/newMorphHelper.py:5:0: W0611: Unused partial imported from functools (unused-import)
************* Module MorphMan.morph.util
morph/util.py:15:4: W0611: Unused typing imported from aqt.pinnedmodules (unused-import)
morph/util.py:16:4: W0611: Unused Tuple imported from typing (unused-import)
************* Module MorphMan.morph.readability
morph/readability.py:89:15: W1114: Positional arguments appear to be out of order (arguments-out-of-order)
************* Module MorphMan.morph.browser.extractMorphemes
morph/browser/extractMorphemes.py:5:0: W0611: Unused ms2str imported from morphemes (unused-import)

-------------------------------------------------------------------
