### PR TITLE
Readability analyzer updates

### DIFF
--- a/morph/config.py
+++ b/morph/config.py
@@ -14,10 +14,6 @@ default = {
     'path_seen': os.path.join(mw.pm.profileFolder(), 'dbs', 'seen.db'),
     'path_log': os.path.join(mw.pm.profileFolder(), 'morphman.log'),
     'path_stats': os.path.join(mw.pm.profileFolder(), 'morphman.stats'),
-    # Default path to Input directory in Readability Analyzer.
-    'path_analysis_input': '',
-    # Default path to Master Frequency List in Readability Analyzer.
-    'path_master_frequency_list': '',
 
     # change the thresholds for various stages of maturity, in days
     'threshold_mature': 21,         # 21 days is what Anki uses
@@ -28,13 +24,15 @@ default = {
     # when you import a file via Extract Morphemes from file, they are all given this maturity
     'text file import maturity': 22,
 
-    # change morpheme parsing
-    # if True, ignores morpheme grammar positions.  Delete your all.db if changing.
-    'ignore grammar position': False,
+    # NOTICE: This option is now set in the Morphman Preferences, and can no longer be set here.
+    #'ignore grammar position': False,
 
-    # Analyzer defaults
-    'default_minimum_master_frequency': 0,   # if not 0, only morphemes with this minimum master frequency are added to study plan.
-    'default_study_target': 98.0,            # morph readability target % for study plan
+    # NOTICE: The following five options are now set via the Readability UI, and can no longer be set here.
+    #'default_minimum_master_frequency': 0,
+    #'default_study_target': 98.0,
+    #'path_master_frequency_list': '',
+    #'path_analysis_input': '',
+    #'ignore grammar position': False,
 
     # reviewer mode keybindings
     'browse same focus key': 'l',

--- a/morph/config.py
+++ b/morph/config.py
@@ -33,7 +33,8 @@ default = {
     'ignore grammar position': False,
 
     # Analyzer defaults
-    'default_study_target': 98.0,
+    'default_minimum_master_frequency': 0,   # if not 0, only morphemes with this minimum master frequency are added to study plan.
+    'default_study_target': 98.0,            # morph readability target % for study plan
 
     # reviewer mode keybindings
     'browse same focus key': 'l',

--- a/morph/customTableWidget.py
+++ b/morph/customTableWidget.py
@@ -1,0 +1,26 @@
+from PyQt5.QtCore import *
+from PyQt5.QtWidgets import *
+from PyQt5.QtGui import *
+from .util import mw
+
+class CustomTableWidget(QTableWidget):
+    def __init__(self, parent):
+        super(CustomTableWidget, self).__init__(parent)
+
+    def keyPressEvent(self, event):
+        if event.matches(QKeySequence.Copy):
+            text = ''
+            sel_range = self.selectionModel().selection().first()
+
+            for y in range(sel_range.top(), sel_range.bottom()+1):
+                for x in range(sel_range.left(), sel_range.right()+1):
+                    if x != sel_range.left(): text += '\t'
+                    text += str(self.item(y,x).text())
+                    pass
+                text += '\n'
+
+            clipboard = QApplication.clipboard()
+            clipboard.setText(text)
+            event.accept()
+            return
+        super(CustomTableWidget, self).keyPressEvent(event)

--- a/morph/main.py
+++ b/morph/main.py
@@ -242,9 +242,13 @@ def updateNotes(allDb):
             except KeyError:
                 continue
 
+        proper_nouns_known = cfg('Option_ProperNounsAlreadyKnown')
+
         # Determine un-seen/known/mature and i+N
         unseens, unknowns, unmatures, new_knowns = set(), set(), set(), set()
         for morpheme in morphemes:
+            if proper_nouns_known and morpheme.isProperNoun():
+                continue
             if not seenDb.matches(morpheme):
                 unseens.add(morpheme)
             if not knownDb.matches(morpheme):
@@ -263,6 +267,7 @@ def updateNotes(allDb):
             continue
 
         # add bonus for morphs in priority.db and frequency.txt
+        frequencyBonus = C('frequency.txt bonus')
         isPriority = False
         isFrequency = False
 
@@ -279,7 +284,6 @@ def updateNotes(allDb):
             try:
                 focusMorphIndex = frequency_list.index(focusMorphString)
                 isFrequency = True
-                frequencyBonus = C('frequency.txt bonus')
 
                 # The bigger this number, the lower mmi becomes
                 usefulness += int(round( frequencyBonus * (1 - focusMorphIndex / frequencyListLength) ))
@@ -310,7 +314,7 @@ def updateNotes(allDb):
         lenDiff = min(9, abs(lenDiffRaw))
 
         # calculate mmi
-        mmi = 100000 * N_k + 1000 * lenDiff + usefulness
+        mmi = 100000 * N_k + 1000 * lenDiff + int(round(usefulness))
         if C('set due based on mmi'):
             nid2mmi[nid] = mmi
 

--- a/morph/morphemes.py
+++ b/morph/morphemes.py
@@ -121,14 +121,16 @@ class MorphDBUnpickler(pickle.Unpickler):
             return globals()[cname]
         return pickle.Unpickler.find_class(self, cmodule, cname)
 
-
-get_morphemes_regex = re.compile(r'\[[^\]]*\]')
-
+square_brackets_regex = re.compile(r'\[[^\]]*\]')
+round_brackets_regex = re.compile(r'（[^）]+）')
 
 def getMorphemes(morphemizer, expression, note_tags=None):
     if cfg('Option_IgnoreBracketContents'):
-        if get_morphemes_regex.search(expression):
-            expression = get_morphemes_regex.sub('', expression)
+        if square_brackets_regex.search(expression):
+            expression = square_brackets_regex.sub('', expression)
+    if cfg('Option_IgnoreRoundBracketContents'):
+        if round_brackets_regex.search(expression):
+            expression = round_brackets_regex.sub('', expression)
 
     # go through all replacement rules and search if a rule (which dictates a string to morpheme conversion) can be
     # applied

--- a/morph/morphemes.py
+++ b/morph/morphemes.py
@@ -101,6 +101,9 @@ class Morpheme:
         else:
             return '%s\t%s\t%s\t' % (self.norm, self.read, self.pos)
 
+    def isProperNoun(self):
+        return (self.subPos == '固有名詞')
+
     def show(self):  # str
         return '\t'.join([self.norm, self.base, self.inflected, self.read, self.pos, self.subPos])
 

--- a/morph/morphemes.py
+++ b/morph/morphemes.py
@@ -96,7 +96,7 @@ class Morpheme:
     def getGroupKey(self):
         # type: () -> str
 
-        if cfg('ignore grammar position'):
+        if cfg('Option_IgnoreGrammarPosition'):
             return '%s\t%s' % (self.norm, self.read)
         else:
             return '%s\t%s\t%s\t' % (self.norm, self.read, self.pos)

--- a/morph/newMorphHelper.py
+++ b/morph/newMorphHelper.py
@@ -50,11 +50,11 @@ def my_fillNew(self, _old):
     if not self.newCount:
         return False
 
-    self._newQueue = self.col.db.all(
-        '''select id, due from cards where did in %s and queue = 0 and due >= ? order by due limit ?''' % self._deckLimit(),
-        C('new card merged fill min due'), self.queueLimit)
-
+    self._newQueue = self.col.db.list(
+        '''select id from cards where did in %s and queue = 0 and due >= ? order by due limit ?''' % self._deckLimit(),
+        C('new card merged fill min due'), self.queueLimit )
     if self._newQueue:
+        self._newQueue.reverse()
         return True
 
 
@@ -96,10 +96,10 @@ def my_getNewCard(self, _old):
             return _old(self)
         if not C('new card merged fill'):
             card = _old(self)  # type: anki.cards.Card
-        else:  # pop from opposite direction and skip sibling spacing
+        else:
             if not self._fillNew():
                 return
-            (card_id, due) = self._newQueue.pop(0)
+            card_id = self._newQueue.pop()
             card = self.col.getCard(card_id)
             self.newCount -= 1
 

--- a/morph/newMorphHelper.py
+++ b/morph/newMorphHelper.py
@@ -254,11 +254,15 @@ def highlight(txt, extra, fieldDict, field, mod_field):
 
     ms = getMorphemes(morphemizer, txt, tags)
 
+    proper_nouns_known = cfg('Option_ProperNounsAlreadyKnown')
+
     for m in sorted(ms, key=lambda x: len(x.inflected), reverse=True):  # largest subs first
         locs = allDb().getMatchingLocs(m)
         mat = max(loc.maturity for loc in locs) if locs else 0
 
-        if mat >= cfg('threshold_mature'):
+        if proper_nouns_known and m.isProperNoun():
+            mtype = 'mature'
+        elif mat >= cfg('threshold_mature'):
             mtype = 'mature'
         elif mat >= cfg('threshold_known'):
             mtype = 'known'
@@ -270,7 +274,6 @@ def highlight(txt, extra, fieldDict, field, mod_field):
         priority = 'true' if m in priority_db else 'false'
 
         focus_morph_string = m.show().split()[0]
-
         frequency = 'true' if focus_morph_string in frequency_list else 'false'
 
         repl = '<span class="morphHighlight" mtype="{mtype}" priority="{priority}" frequency="{frequency}" mat="{mat}">\\1</span>'.format(

--- a/morph/preferences.py
+++ b/morph/preferences.py
@@ -128,7 +128,13 @@ def jcfg_default():
         'Option_ProperNounsAlreadyKnown': False,
         
         # Readability Analyzer options
+        'Option_AnalysisInputPath': '',
+        'Option_MasterFrequencyListPath': '',
+        'Option_DefaultMinimumMasterFrequency': 0,
+        'Option_DefaultStudyTarget': 98.0,
         'Option_FillAllMorphsInStudyPlan': False,
+        'Option_SourceScorePower': 2.0,            # Morpheme score formula parameter.
+        'Option_SourceScoreMultiplier': 60.0,      # Morpheme score formula parameter.
     }
 
 

--- a/morph/preferences.py
+++ b/morph/preferences.py
@@ -124,6 +124,7 @@ def jcfg_default():
         'Option_SkipFocusMorphSeenToday': True,
         # bury/skip all new cards that have a focus morph that was reviewed today/marked as `already known`
         'Option_IgnoreBracketContents': False,
+        'Option_IgnoreRoundBracketContents': False,
         'Option_ProperNounsAlreadyKnown':False,
     }
 

--- a/morph/preferences.py
+++ b/morph/preferences.py
@@ -125,7 +125,10 @@ def jcfg_default():
         # bury/skip all new cards that have a focus morph that was reviewed today/marked as `already known`
         'Option_IgnoreBracketContents': False,
         'Option_IgnoreRoundBracketContents': False,
-        'Option_ProperNounsAlreadyKnown':False,
+        'Option_ProperNounsAlreadyKnown': False,
+        
+        # Readability Analyzer options
+        'Option_FillAllMorphsInStudyPlan': False,
     }
 
 

--- a/morph/preferences.py
+++ b/morph/preferences.py
@@ -124,6 +124,7 @@ def jcfg_default():
         'Option_SkipFocusMorphSeenToday': True,
         # bury/skip all new cards that have a focus morph that was reviewed today/marked as `already known`
         'Option_IgnoreBracketContents': False,
+        'Option_ProperNounsAlreadyKnown':False,
     }
 
 

--- a/morph/preferencesDialog.py
+++ b/morph/preferencesDialog.py
@@ -204,6 +204,8 @@ class PreferencesDialog(QDialog):
              'Note that does not contain unknown words, but one or\nmore unmature (card with recently learned morphmes). Enable to\nskip to first card that has unknown vocabulary.'),
             ("Skip card if focus morph was already seen today", 'Option_SkipFocusMorphSeenToday',
              'This improves the \'new cards\'-queue without having to recalculate the databases.'),
+            ("Ignore grammar position", 'Option_IgnoreGrammarPosition',
+             'Use this option to ignore morpheme grammar types (noun, verb, helper, etc.).'),
             ("Ignore everything contained within [ ] brackets", 'Option_IgnoreBracketContents',
              'Use this option to ignore content such as furigana readings and pitch.'),
             ("Ignore everything contained within （ ） brackets", 'Option_IgnoreRoundBracketContents',

--- a/morph/preferencesDialog.py
+++ b/morph/preferencesDialog.py
@@ -206,6 +206,8 @@ class PreferencesDialog(QDialog):
              'This improves the \'new cards\'-queue without having to recalculate the databases.'),
             ("Ignore everything contained within [ ] brackets", 'Option_IgnoreBracketContents',
              'Use this option to ignore content such as furigana readings and pitch.'),
+            ("Ignore everything contained within （ ） brackets", 'Option_IgnoreRoundBracketContents',
+             'Use this option to ignore content such as character names and readings in scripts.'),
             ("Treat proper nouns as known", 'Option_ProperNounsAlreadyKnown',
              'Treat proper nouns as already known when scoring cards (currently only works for Japanese).')
         ]

--- a/morph/preferencesDialog.py
+++ b/morph/preferencesDialog.py
@@ -205,7 +205,9 @@ class PreferencesDialog(QDialog):
             ("Skip card if focus morph was already seen today", 'Option_SkipFocusMorphSeenToday',
              'This improves the \'new cards\'-queue without having to recalculate the databases.'),
             ("Ignore everything contained within [ ] brackets", 'Option_IgnoreBracketContents',
-             'Use this option to ignore content such as furigana readings and pitch.')
+             'Use this option to ignore content such as furigana readings and pitch.'),
+            ("Treat proper nouns as known", 'Option_ProperNounsAlreadyKnown',
+             'Treat proper nouns as already known when scoring cards (currently only works for Japanese).')
         ]
         self.boolOptionList = []
         for i, (name, key, tooltipInfo) in enumerate(optionList):

--- a/morph/readability.py
+++ b/morph/readability.py
@@ -119,10 +119,10 @@ class MorphMan(QDialog):
         self.ui.morphemizerComboBox.currentIndexChanged.connect(lambda idx: self.save_morphemizer())
 
         # Default settings
-        self.ui.inputPathEdit.setText(cfg('path_analysis_input'))
+        self.ui.inputPathEdit.setText(cfg('Option_AnalysisInputPath'))
         self.ui.inputPathButton.clicked.connect(
             lambda le: getPath(self.ui.inputPathEdit, "Select Input Directory", True))
-        self.ui.masterFreqEdit.setText(cfg('path_master_frequency_list'))
+        self.ui.masterFreqEdit.setText(cfg('Option_MasterFrequencyListPath'))
         self.ui.masterFreqButton.clicked.connect(
             lambda le: getPath(self.ui.masterFreqEdit, "Select Master Frequency List"))
         self.ui.knownMorphsEdit.setText(cfg('path_known'))
@@ -130,8 +130,8 @@ class MorphMan(QDialog):
         self.ui.outputFrequencyEdit.setText(cfg('path_dbs'))
         self.ui.outputFrequencyButton.clicked.connect(
             lambda le: getPath(self.ui.outputFrequencyEdit, "Select Output Directory", True))
-        self.ui.minFrequencySpinBox.setProperty("value", cfg('default_minimum_master_frequency'))
-        self.ui.targetSpinBox.setProperty("value", cfg('default_study_target'))
+        self.ui.minFrequencySpinBox.setProperty("value", cfg('Option_DefaultMinimumMasterFrequency'))
+        self.ui.targetSpinBox.setProperty("value", cfg('Option_DefaultStudyTarget'))
 
         # Connect buttons
         self.ui.analyzeButton.clicked.connect(lambda le: self.onAnalyze())
@@ -174,8 +174,16 @@ class MorphMan(QDialog):
         save_word_report = self.ui.wordReportCheckBox.isChecked()
         save_study_plan = self.ui.studyPlanCheckBox.isChecked()
 
-        source_score_power = 2.0
-        source_score_multiplier = 60.0
+        # Save updated preferences
+        pref = {}
+        pref['Option_AnalysisInputPath'] = input_path
+        pref['Option_MasterFrequencyListPath'] = master_freq_path
+        pref['Option_DefaultMinimumMasterFrequency'] = minimum_master_frequency
+        pref['Option_DefaultStudyTarget'] = readability_target
+        update_preferences(pref)
+
+        source_score_power = cfg('Option_SourceScorePower')
+        source_score_multiplier = cfg('Option_SourceScoreMultiplier')
 
         proper_nouns_known = cfg('Option_ProperNounsAlreadyKnown')
         fill_all_morphs_in_plan = cfg('Option_FillAllMorphsInStudyPlan')

--- a/morph/readability.py
+++ b/morph/readability.py
@@ -300,7 +300,8 @@ class MorphMan(QDialog):
                     line_morphs.append(line_missing_morphs)
 
                 filtered_text = ''
-                for t in text.split('\n'):
+                for t in text.splitlines():
+                    should_flush = True
                     if is_ass:
                         if 'Format:' in t:
                             formats = [x.strip() for x in t[8:].split(',')]
@@ -312,7 +313,7 @@ class MorphMan(QDialog):
                             continue
                         elif ('Dialogue:' not in t) or (text_index < 0):
                             continue
-                        t = t[9:].split(',', num_fields)
+                        t = t[9:].split(',', num_fields - 1)
                         t = t[text_index]
                     elif is_srt:
                         srt_count += 1
@@ -320,11 +321,16 @@ class MorphMan(QDialog):
                             continue
                         elif t == '':
                             srt_count = 0
-                            continue
-                    filtered_text += t + '\n'
+                        else:
+                            should_flush = False
+                    
+                    if t != '':
+                        filtered_text += t + '\n'
+                    
                     # Todo: This will flush every line so we can compute per-line readability, which is slower than batching lines.
                     #       Figure out how to get per-line analysis with batched lines.
-                    if True:
+                    if should_flush:
+                    #if len(filtered_text) >= 2048:
                         parse_text(filtered_text)
                         filtered_text = ''
 

--- a/morph/readability.py
+++ b/morph/readability.py
@@ -178,6 +178,7 @@ class MorphMan(QDialog):
         source_score_multiplier = 60.0
 
         proper_nouns_known = cfg('Option_ProperNounsAlreadyKnown')
+        fill_all_morphs_in_plan = cfg('Option_FillAllMorphsInStudyPlan')
 
         if not os.path.exists(output_path):
             try:
@@ -544,13 +545,14 @@ class MorphMan(QDialog):
                             print(m[0].base + '\t[score %d ep_freq %d all_freq %d master_freq %d]' % (m[5], m[2], m[3], m[4]), file=f)
                         
                         # Followed by all remaining morphs sorted by score.
-                        for m in sorted(all_missing_morphs, key=operator.itemgetter(5), reverse=True):
-                            if (m[0].base in unique_set):
-                                continue
-                            if m[4] < minimum_master_frequency:
-                                continue
-                            unique_set.add(m[0].base)
-                            print(m[0].base + '\t[score %d ep_freq %d all_freq %d master_freq %d]' % (m[5], m[2], m[3], m[4]), file=f)
+                        if fill_all_morphs_in_plan:
+                            for m in sorted(all_missing_morphs, key=operator.itemgetter(5), reverse=True):
+                                if (m[0].base in unique_set):
+                                    continue
+                                if m[4] < minimum_master_frequency:
+                                    continue
+                                unique_set.add(m[0].base)
+                                print(m[0].base + '\t[score %d ep_freq %d all_freq %d master_freq %d]' % (m[5], m[2], m[3], m[4]), file=f)
                 
                 if master_total_instances > 0:
                     master_score = 0

--- a/morph/readability.py
+++ b/morph/readability.py
@@ -7,17 +7,20 @@ import operator
 import os
 import re
 
+from PyQt5.QtCore import *
 from PyQt5.QtGui import *
 from PyQt5.QtWidgets import *
 
+from . import customTableWidget
 from . import readability_ui
 from .morphemes import Morpheme, MorphDb, getMorphemes, altIncludesMorpheme
 from .morphemizer import getAllMorphemizers
-from .util import mw
 from .preferences import get_preference as cfg, update_preferences
+from .util import mw
+from anki.utils import stripHTML
 
+importlib.reload(customTableWidget)
 importlib.reload(readability_ui)
-
 
 def atoi(text):
     return int(text) if text.isdigit() else text
@@ -33,9 +36,10 @@ def natural_keys(text):
 
 
 class Source:
-    def __init__(self, name, morphs, unknown_db):
+    def __init__(self, name, morphs, line_morphs, unknown_db):
         self.name = os.path.basename(name)
         self.morphs = morphs
+        self.line_morphs = line_morphs
         self.unknown_db = unknown_db
 
 
@@ -77,7 +81,7 @@ class CountingMorphDB:
     def getTotalVariationMorphs(self):
         return sum([len(ms) for ms in self.db.values()])
 
-    def getFuzzyCount(self, m):
+    def getFuzzyCount(self, m, exclude_db):
         gk = m.getGroupKey()
         if gk not in self.db:
             return 0
@@ -86,10 +90,21 @@ class CountingMorphDB:
         for alt, c in ms.items():
             if c[1]:  # Skip marked morphs
                 continue
+            if exclude_db.matches(alt): # Skip excluded morphs
+                continue
             if altIncludesMorpheme(alt, m):  # pylint: disable=W1114 #ToDo: verify if pylint is right
                 count += c[0]
         return count
 
+class TableInteger(QTableWidgetItem):
+    def __init__(self, value):
+        super(TableInteger, self).__init__(str(int(value)))
+        self.setTextAlignment( Qt.AlignHCenter | Qt.AlignVCenter );
+
+class TablePercent(QTableWidgetItem):
+    def __init__(self, value):
+        super(TablePercent, self).__init__('%0.02f' % value)
+        self.setTextAlignment( Qt.AlignHCenter | Qt.AlignVCenter );
 
 class MorphMan(QDialog):
     def __init__(self, parent=None):
@@ -115,6 +130,7 @@ class MorphMan(QDialog):
         self.ui.outputFrequencyEdit.setText(cfg('path_dbs'))
         self.ui.outputFrequencyButton.clicked.connect(
             lambda le: getPath(self.ui.outputFrequencyEdit, "Select Output Directory", True))
+        self.ui.minFrequencySpinBox.setProperty("value", cfg('default_minimum_master_frequency'))
         self.ui.targetSpinBox.setProperty("value", cfg('default_study_target'))
 
         # Connect buttons
@@ -146,8 +162,10 @@ class MorphMan(QDialog):
 
         morphemizer = self.morphemizer()
         self.writeOutput('Using morphemizer: %s \n' % morphemizer.getDescription())
+        debug_output = False
 
         input_path = self.ui.inputPathEdit.text()
+        minimum_master_frequency = int(self.ui.minFrequencySpinBox.value())
         readability_target = float(self.ui.targetSpinBox.value())
         master_freq_path = self.ui.masterFreqEdit.text()
         known_words_path = self.ui.knownMorphsEdit.text()
@@ -155,6 +173,9 @@ class MorphMan(QDialog):
         save_frequency_list = self.ui.frequencyListCheckBox.isChecked()
         save_word_report = self.ui.wordReportCheckBox.isChecked()
         save_study_plan = self.ui.studyPlanCheckBox.isChecked()
+
+        source_score_power = 2.0
+        source_score_multiplier = 60.0
 
         if not os.path.exists(output_path):
             try:
@@ -172,7 +193,6 @@ class MorphMan(QDialog):
 
         master_total_instances = 0
         master_current_score = 0
-        master_weight = 1.0
 
         all_morphs = {}
 
@@ -192,6 +212,7 @@ class MorphMan(QDialog):
                 master_db.getTotalNormMorphs(), master_db.getTotalVariationMorphs()))
         else:
             self.writeOutput("Master frequency file '%s' not found.\n" % master_freq_path)
+            minimum_master_frequency = 0
 
         if os.path.isfile(known_words_path):
             known_db = MorphDb(known_words_path, ignoreErrors=True)
@@ -217,6 +238,10 @@ class MorphMan(QDialog):
 
         def measure_readability(file_name, is_ass, is_srt):
             i_count = 0
+            line_count = 0
+            line_morphs = []
+            known_line_count = 0
+            iplus1_line_count = 0
             known_count = 0
             seen_morphs = {}
             known_morphs = {}
@@ -229,12 +254,17 @@ class MorphMan(QDialog):
 
                 def parse_text(text):
                     nonlocal i_count, known_count, seen_morphs, known_morphs, all_morphs
+                    nonlocal line_count, known_line_count, iplus1_line_count, line_morphs
 
-                    parsed_morphs = getMorphemes(morphemizer, text)
+                    parsed_morphs = getMorphemes(morphemizer, stripHTML(text))
+                    if len(parsed_morphs) == 0:
+                        return
+
+                    unknown_count = 0
+                    line_missing_morphs = set()
                     for m in parsed_morphs:
                         # Count morph for word report
                         all_morphs[m] = all_morphs.get(m, 0) + 1
-
                         seen_morphs[m] = seen_morphs.get(m, 0) + 1
                         i_count += 1
                         if known_db.matches(m):
@@ -243,6 +273,14 @@ class MorphMan(QDialog):
                         else:
                             unknown_db.addMorph(m, 1)
                             source_unknown_db.addMorph(m, 1)
+                            line_missing_morphs.add(m)
+                            unknown_count += 1
+                    line_count += 1
+                    if unknown_count == 0:
+                        known_line_count += 1
+                    elif unknown_count == 1:
+                        iplus1_line_count += 1
+                    line_morphs.append(line_missing_morphs)
 
                 filtered_text = ''
                 for t in text.split('\n'):
@@ -267,7 +305,9 @@ class MorphMan(QDialog):
                             srt_count = 0
                             continue
                     filtered_text += t + '\n'
-                    if len(filtered_text) >= 2048:
+                    # Todo: This will flush every line so we can compute per-line readability, which is slower than batching lines.
+                    #       Figure out how to get per-line analysis with batched lines.
+                    if True:
                         parse_text(filtered_text)
                         filtered_text = ''
 
@@ -277,13 +317,25 @@ class MorphMan(QDialog):
                 with open(file_name.strip(), 'rt', encoding='utf-8') as f:
                     input = '\n'.join([l.strip().replace(u'\ufeff', '') for l in f.readlines()])
                     proc_lines(input, is_ass, is_srt)
-                    source = Source(file_name, seen_morphs, source_unknown_db)
+                    source = Source(file_name, seen_morphs, line_morphs, source_unknown_db)
                     readability = 0.0 if i_count == 0 else 100.0 * known_count / i_count
-                    known_percent = 0.0 if len(seen_morphs.keys()) == 0 else 100.0 * len(known_morphs) / len(
-                        seen_morphs.keys())
-                    self.writeOutput('%s\t%d\t%d\t%0.2f\t%d\t%d\t%0.2f\n' % (
+                    known_percent = 0.0 if len(seen_morphs.keys()) == 0 else 100.0 * len(known_morphs) / len(seen_morphs.keys())
+                    line_percent = 0.0 if known_line_count == 0 else 100.0 * known_line_count / line_count
+                    iplus1_percent = 0.0 if known_line_count == 0 else 100.0 * iplus1_line_count / line_count
+                    self.writeOutput('%s\t%d\t%d\t%0.2f\t%d\t%d\t%0.2f\t%0.2f\n' % (
                         source.name, len(seen_morphs), len(known_morphs), known_percent, i_count, known_count,
-                        readability))
+                        readability, line_percent))
+                    row = self.ui.readabilityTable.rowCount()
+                    self.ui.readabilityTable.insertRow(row)
+                    self.ui.readabilityTable.setItem(row, 0, QTableWidgetItem(source.name))
+                    self.ui.readabilityTable.setItem(row, 1, TableInteger(len(seen_morphs)))
+                    self.ui.readabilityTable.setItem(row, 2, TableInteger(len(known_morphs)))
+                    self.ui.readabilityTable.setItem(row, 3, TablePercent(known_percent))
+                    self.ui.readabilityTable.setItem(row, 4, TableInteger(i_count))
+                    self.ui.readabilityTable.setItem(row, 5, TableInteger(known_count))
+                    self.ui.readabilityTable.setItem(row, 6, TablePercent(readability))
+                    self.ui.readabilityTable.setItem(row, 7, TablePercent(line_percent))
+                    self.ui.readabilityTable.setItem(row, 8, TablePercent(iplus1_percent))
 
                     if save_study_plan:
                         sources.append(source)
@@ -298,12 +350,19 @@ class MorphMan(QDialog):
         for (dirpath, _, filenames) in os.walk(input_path):
             list_of_files += [os.path.join(dirpath, filename) for filename in filenames if accepted_filetype(filename)]
 
-        if len(list_of_files) > 0:
-            self.writeOutput('%s\t%s\t%s\t%s\t%s\t%s\t%s\n' % (
-                "Input", "Total Morphs", "Known Morphs", "% Known Morphs", "Total Instances", "Known Instances",
-                "% Readability"))
+        self.ui.readabilityTable.clear()
+        self.ui.readabilityTable.setRowCount(0)
+        self.ui.readabilityTable.setColumnCount(9)
+        self.ui.readabilityTable.setHorizontalHeaderLabels([
+            "Input", "Total\nMorphs", "Known\nMorphs", "Known\nMorphs %", "Total\nInstances", "Known\nInstances",
+            "Morph\nReadability %", "Line\nReadability %", "i+1\nLines %"])
 
-            mw.progress.start(label='Updating data', max=len(list_of_files), immediate=True)
+        if len(list_of_files) > 0:
+            self.writeOutput('%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\n' % (
+                "Input", "Total Morphs", "Known Morphs","% Known Morphs", "Total Instances", "Known Instances",
+                "% Readability", "% Known Lines"))
+
+            mw.progress.start( label='Measuring readability', max=len(list_of_files), immediate=True )
             for n, file_path in enumerate(sorted(list_of_files, key=natural_keys)):
                 mw.progress.update(value=n, label='Parsing (%d/%d) %s' % (
                     n + 1, len(list_of_files), os.path.basename(file_path)))
@@ -315,6 +374,8 @@ class MorphMan(QDialog):
         else:
             self.writeOutput('\nNo files found to process.\n')
             return
+
+        self.ui.readabilityTable.resizeColumnsToContents()
 
         if save_word_report:
             self.writeOutput("\n[Saving word report to '%s'...]\n" % word_report_path)
@@ -332,23 +393,50 @@ class MorphMan(QDialog):
                     morph_idx += 1
                     morph_delta = 100.0 * m[1] / all_morphs_count
                     morph_total += morph_delta
-                    print('%d\t%s\t%s\t%s\t%s\t%s\t%d\t%d\t%0.8f\t%0.8f' % (
+                    print('%d\t%s\t%s\t%s\t%s\t%s\t%d\t%d\t%0.8f\t%0.8f matches %d' % (
                         m[1], m[0].norm, m[0].base, m[0].read, m[0].pos, m[0].subPos, group_idx, morph_idx, morph_delta,
-                        morph_total), file=f)
+                        morph_total, known_db.matches(m[0])), file=f)
 
         learned_tot = 0
         learned_morphs = []
 
         all_missing_morphs = []
 
+        def get_line_readability(show, known_db):
+            known_lines = 0
+            for line_morphs in show.line_morphs:
+                has_unknowns = False
+                for m in line_morphs:
+                    if known_db.matches(m):
+                        continue
+                    has_unknowns = True
+                if not has_unknowns:
+                    known_lines += 1
+            line_readability = 0.0 if known_lines == 0 else 100.0 * known_lines / len(show.line_morphs)
+            return line_readability
+
         if save_study_plan:
             self.writeOutput("\n[Saving Study Plan to '%s'...]\n" % study_plan_path)
             with open(study_plan_path, 'wt', encoding='utf-8') as f:
+                self.ui.studyPlanTable.clear()
+                self.ui.studyPlanTable.setRowCount(0)
+                self.ui.studyPlanTable.setColumnCount(7)
+                self.ui.studyPlanTable.setHorizontalHeaderLabels([
+                    "Input", "To Study\nMorphs ", "Cummulative\nMorphs", "Old Morph\nReadability %", "New Morph\nReadability %",
+                    "Old Line\nReadability %", "New Line\nReadability %"])
+
+                mw.progress.start( label='Building study plan', max=len(sources), immediate=True )
+
                 for n, s in enumerate(sources):
+                    mw.progress.update( value=n, label='Processing (%d/%d) %s' % (n+1, len(sources), os.path.basename(s.name)) )
+                    if debug_output: f.write('Processing %s\n' % s.name)
+
                     known_i = 0
                     seen_i = 0
                     learned_m = 0
                     missing_morphs = []
+
+                    old_line_readability = get_line_readability(s, known_db)
 
                     for m in s.morphs.items():
                         seen_i += m[1]
@@ -356,46 +444,65 @@ class MorphMan(QDialog):
                         if known_db.matches(morph):
                             known_i += m[1]
                         else:
-                            source_unknown_count = s.unknown_db.getFuzzyCount(morph)
-                            unknown_count = unknown_db.getFuzzyCount(morph)
-                            master_count = master_db.getFuzzyCount(morph)
-                            
+                            source_unknown_count = s.unknown_db.getFuzzyCount(morph, known_db)
+                            unknown_count = unknown_db.getFuzzyCount(morph, known_db)
+                            master_count = master_db.getFuzzyCount(morph, known_db)
                             source_count = source_unknown_count + unknown_count
 
-                            score = pow(source_count, 2) * 60 + master_count * master_weight
-                            missing_morphs.append((m[0], source_unknown_count, unknown_count, master_count, score))
+                            score = pow(source_count, source_score_power) * source_score_multiplier + master_count
+                            missing_morphs.append((m[0], m[1], source_unknown_count, unknown_count, master_count, score))
+
+                            if debug_output: f.write('  missing: ' + m[0].show() + '\t[score %d ep_freq %d all_freq %d master_freq %d]\n' % (score, source_unknown_count, unknown_count, master_count))
 
                     all_missing_morphs += missing_morphs
-
-                    if seen_i > 0:
-                        readability = known_i * 100.0 / seen_i
-                    else:
-                        readability = 100.0
-                    readability_0 = readability
+                    readability = 100.0 if seen_i == 0 else known_i * 100.0 / seen_i
+                    old_readability = readability
 
                     learned_this_source = []
 
-                    for m in sorted(missing_morphs, key=operator.itemgetter(4), reverse=True):
+                    for m in sorted(missing_morphs, key=operator.itemgetter(5), reverse=True):
                         if readability >= readability_target:
+                            if debug_output: f.write('  readability target reached\n')
                             break
+
                         if known_db.matches(m[0]):
+                            if debug_output: f.write('  known: %s\n' % m[0].show())
+                            continue
+
+                        if m[4] < minimum_master_frequency:
+                            if debug_output: f.write('  low score: %s [score %d ep_freq %d all_freq %d master_freq %d]\n' % (m[0].show(), m[5], m[2], m[3], m[4]))
                             continue
                         
-                        known_db.addMLs1(m[0], set())
                         learned_morphs.append(m)
                         learned_this_source.append(m)
-                        known_i += m[1]
+                        known_i += s.unknown_db.getFuzzyCount(m[0], known_db)
                         learned_m += 1
-                        readability = known_i * 100.0 / seen_i
+                        readability = 100.0 if seen_i == 0 else known_i * 100.0 / seen_i
+                        known_db.addMLs1(m[0], set())
+
+                    new_line_readability = get_line_readability(s, known_db)
 
                     learned_tot += learned_m
-                    source_str = "'%s' study goal: (%3d/%4d) readability: %0.2f -> %0.2f\n" % (
-                        s.name, learned_m, learned_tot, readability_0, readability)
+                    source_str = "'%s' study goal: (%3d/%4d) morph readability: %0.2f -> %0.2f line readabiltiy: %0.2f -> %0.2f\n" % (
+                        s.name, learned_m, learned_tot, old_readability, readability, old_line_readability, new_line_readability)
                     self.writeOutput(source_str)
                     f.write(source_str)
 
+                    row = self.ui.studyPlanTable.rowCount()
+                    self.ui.studyPlanTable.insertRow(row)
+                    self.ui.studyPlanTable.setItem(row, 0, QTableWidgetItem(s.name))
+                    self.ui.studyPlanTable.setItem(row, 1, TableInteger(learned_m))
+                    self.ui.studyPlanTable.setItem(row, 2, TableInteger(learned_tot))
+                    self.ui.studyPlanTable.setItem(row, 3, TablePercent(old_readability))
+                    self.ui.studyPlanTable.setItem(row, 4, TablePercent(readability))
+                    self.ui.studyPlanTable.setItem(row, 5, TablePercent(old_line_readability))
+                    self.ui.studyPlanTable.setItem(row, 6, TablePercent(new_line_readability))
+
                     for m in learned_this_source:
-                        f.write('\t' + m[0].show() + '\t[score %d ep_freq %d all_freq %d master_freq %d]\n' % (m[4], m[1], m[2], m[3]))
+                        f.write('\t' + m[0].show() + '\t[score %d ep_freq %d all_freq %d master_freq %d]\n' % (m[5], m[2], m[3], m[4]))
+
+                self.ui.studyPlanTable.resizeColumnsToContents()
+                mw.progress.finish()
 
                 if save_frequency_list:
                     self.writeOutput("\n[Saving frequency list to '%s'...]\n" % frequency_list_path)
@@ -406,14 +513,16 @@ class MorphMan(QDialog):
                             if m[0].base in unique_set:
                                 continue
                             unique_set.add(m[0].base)
-                            print(m[0].base + '\t[score %d ep_freq %d all_freq %d master_freq %d]' % (m[4], m[1], m[2], m[3]), file=f)
+                            print(m[0].base + '\t[score %d ep_freq %d all_freq %d master_freq %d]' % (m[5], m[2], m[3], m[4]), file=f)
                         
                         # Followed by all remaining morphs sorted by score.
-                        for m in sorted(all_missing_morphs, key=operator.itemgetter(4), reverse=True):
-                            if m[0].base in unique_set:
+                        for m in sorted(all_missing_morphs, key=operator.itemgetter(5), reverse=True):
+                            if (m[0].base in unique_set):
+                                continue
+                            if m[4] < minimum_master_frequency:
                                 continue
                             unique_set.add(m[0].base)
-                            print(m[0].base + '\t[score %d ep_freq %d all_freq %d master_freq %d]' % (m[4], m[1], m[2], m[3]), file=f)
+                            print(m[0].base + '\t[score %d ep_freq %d all_freq %d master_freq %d]' % (m[5], m[2], m[3], m[4]), file=f)
                 
                 if master_total_instances > 0:
                     master_score = 0

--- a/morph/readability.ui
+++ b/morph/readability.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>956</width>
-    <height>722</height>
+    <width>898</width>
+    <height>781</height>
    </rect>
   </property>
   <property name="sizePolicy">
@@ -115,6 +115,20 @@
              </size>
             </property>
            </spacer>
+          </item>
+          <item>
+           <widget class="QLabel" name="minFrequencyLabel">
+            <property name="text">
+             <string>Minimum Master Frequency</string>
+            </property>
+           </widget>
+          </item>
+          <item>
+           <widget class="QSpinBox" name="minFrequencySpinBox">
+            <property name="maximum">
+             <number>200000</number>
+            </property>
+           </widget>
           </item>
           <item>
            <widget class="QLabel" name="targetLabel">
@@ -379,10 +393,67 @@
       <number>6</number>
      </property>
      <item>
-      <widget class="QPlainTextEdit" name="outputText">
-       <property name="readOnly">
-        <bool>true</bool>
+      <widget class="QTabWidget" name="tabWidget">
+       <property name="currentIndex">
+        <number>1</number>
        </property>
+       <widget class="QWidget" name="tabOutputLog">
+        <attribute name="title">
+         <string>Output Log</string>
+        </attribute>
+        <layout class="QVBoxLayout" name="verticalLayout_2">
+         <item>
+          <widget class="QPlainTextEdit" name="outputText">
+           <property name="sizePolicy">
+            <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
+             <horstretch>0</horstretch>
+             <verstretch>0</verstretch>
+            </sizepolicy>
+           </property>
+           <property name="readOnly">
+            <bool>true</bool>
+           </property>
+          </widget>
+         </item>
+        </layout>
+       </widget>
+       <widget class="QWidget" name="tabReadabilityReport">
+        <attribute name="title">
+         <string>Readability Report</string>
+        </attribute>
+        <layout class="QVBoxLayout" name="verticalLayout_3">
+         <item>
+          <widget class="CustomTableWidget" name="readabilityTable">
+           <property name="editTriggers">
+            <set>QAbstractItemView::NoEditTriggers</set>
+           </property>
+           <property name="selectionBehavior">
+            <enum>QAbstractItemView::SelectItems</enum>
+           </property>
+           <property name="rowCount">
+            <number>0</number>
+           </property>
+           <property name="columnCount">
+            <number>0</number>
+           </property>
+          </widget>
+         </item>
+        </layout>
+       </widget>
+       <widget class="QWidget" name="tabStudyPlan">
+        <attribute name="title">
+         <string>Study Plan</string>
+        </attribute>
+        <layout class="QVBoxLayout" name="verticalLayout_4">
+         <item>
+          <widget class="CustomTableWidget" name="studyPlanTable">
+           <property name="editTriggers">
+            <set>QAbstractItemView::NoEditTriggers</set>
+           </property>
+          </widget>
+         </item>
+        </layout>
+       </widget>
       </widget>
      </item>
     </layout>
@@ -393,7 +464,12 @@
   <customwidget>
    <class>MorphemizerComboBox</class>
    <extends>QComboBox</extends>
-   <header>__relpath__/UI/</header>
+   <header>.UI</header>
+  </customwidget>
+  <customwidget>
+   <class>CustomTableWidget</class>
+   <extends>QTableWidget</extends>
+   <header>.customTableWidget.h</header>
   </customwidget>
  </customwidgets>
  <resources/>

--- a/morph/readability_ui.py
+++ b/morph/readability_ui.py
@@ -1,8 +1,8 @@
 # -*- coding: utf-8 -*-
 
-# Form implementation generated from reading ui file 'morph/readability.ui'
+# Form implementation generated from reading ui file 'readability.ui'
 #
-# Created by: PyQt5 UI code generator 5.14.0
+# Created by: PyQt5 UI code generator 5.13.0
 #
 # WARNING! All changes made in this file will be lost!
 
@@ -13,7 +13,7 @@ from PyQt5 import QtCore, QtGui, QtWidgets
 class Ui_ReadabilityDialog(object):
     def setupUi(self, ReadabilityDialog):
         ReadabilityDialog.setObjectName("ReadabilityDialog")
-        ReadabilityDialog.resize(956, 722)
+        ReadabilityDialog.resize(898, 781)
         sizePolicy = QtWidgets.QSizePolicy(QtWidgets.QSizePolicy.Fixed, QtWidgets.QSizePolicy.Fixed)
         sizePolicy.setHorizontalStretch(0)
         sizePolicy.setVerticalStretch(0)
@@ -59,6 +59,13 @@ class Ui_ReadabilityDialog(object):
         self.horizontalLayout_4.addWidget(self.morphemizerComboBox)
         spacerItem = QtWidgets.QSpacerItem(40, 20, QtWidgets.QSizePolicy.Expanding, QtWidgets.QSizePolicy.Minimum)
         self.horizontalLayout_4.addItem(spacerItem)
+        self.minFrequencyLabel = QtWidgets.QLabel(self.frame)
+        self.minFrequencyLabel.setObjectName("minFrequencyLabel")
+        self.horizontalLayout_4.addWidget(self.minFrequencyLabel)
+        self.minFrequencySpinBox = QtWidgets.QSpinBox(self.frame)
+        self.minFrequencySpinBox.setMaximum(200000)
+        self.minFrequencySpinBox.setObjectName("minFrequencySpinBox")
+        self.horizontalLayout_4.addWidget(self.minFrequencySpinBox)
         self.targetLabel = QtWidgets.QLabel(self.frame)
         self.targetLabel.setAlignment(QtCore.Qt.AlignRight|QtCore.Qt.AlignTrailing|QtCore.Qt.AlignVCenter)
         self.targetLabel.setObjectName("targetLabel")
@@ -175,13 +182,50 @@ class Ui_ReadabilityDialog(object):
         self.horizontalLayout_3 = QtWidgets.QHBoxLayout()
         self.horizontalLayout_3.setContentsMargins(6, -1, 6, -1)
         self.horizontalLayout_3.setObjectName("horizontalLayout_3")
-        self.outputText = QtWidgets.QPlainTextEdit(ReadabilityDialog)
+        self.tabWidget = QtWidgets.QTabWidget(ReadabilityDialog)
+        self.tabWidget.setObjectName("tabWidget")
+        self.tabOutputLog = QtWidgets.QWidget()
+        self.tabOutputLog.setObjectName("tabOutputLog")
+        self.verticalLayout_21 = QtWidgets.QVBoxLayout(self.tabOutputLog)
+        self.verticalLayout_21.setObjectName("verticalLayout_21")
+        self.outputText = QtWidgets.QPlainTextEdit(self.tabOutputLog)
+        sizePolicy = QtWidgets.QSizePolicy(QtWidgets.QSizePolicy.Expanding, QtWidgets.QSizePolicy.Expanding)
+        sizePolicy.setHorizontalStretch(0)
+        sizePolicy.setVerticalStretch(0)
+        sizePolicy.setHeightForWidth(self.outputText.sizePolicy().hasHeightForWidth())
+        self.outputText.setSizePolicy(sizePolicy)
         self.outputText.setReadOnly(True)
         self.outputText.setObjectName("outputText")
-        self.horizontalLayout_3.addWidget(self.outputText)
+        self.verticalLayout_21.addWidget(self.outputText)
+        self.tabWidget.addTab(self.tabOutputLog, "")
+        self.tabReadabilityReport = QtWidgets.QWidget()
+        self.tabReadabilityReport.setObjectName("tabReadabilityReport")
+        self.verticalLayout_31 = QtWidgets.QVBoxLayout(self.tabReadabilityReport)
+        self.verticalLayout_31.setObjectName("verticalLayout_31")
+        self.readabilityTable = CustomTableWidget(self.tabReadabilityReport)
+        self.readabilityTable.setEditTriggers(QtWidgets.QAbstractItemView.NoEditTriggers)
+        self.readabilityTable.setSelectionBehavior(QtWidgets.QAbstractItemView.SelectItems)
+        self.readabilityTable.setRowCount(0)
+        self.readabilityTable.setColumnCount(0)
+        self.readabilityTable.setObjectName("readabilityTable")
+        self.verticalLayout_31.addWidget(self.readabilityTable)
+        self.tabWidget.addTab(self.tabReadabilityReport, "")
+        self.tabStudyPlan = QtWidgets.QWidget()
+        self.tabStudyPlan.setObjectName("tabStudyPlan")
+        self.verticalLayout_41 = QtWidgets.QVBoxLayout(self.tabStudyPlan)
+        self.verticalLayout_41.setObjectName("verticalLayout_41")
+        self.studyPlanTable = CustomTableWidget(self.tabStudyPlan)
+        self.studyPlanTable.setEditTriggers(QtWidgets.QAbstractItemView.NoEditTriggers)
+        self.studyPlanTable.setObjectName("studyPlanTable")
+        self.studyPlanTable.setColumnCount(0)
+        self.studyPlanTable.setRowCount(0)
+        self.verticalLayout_41.addWidget(self.studyPlanTable)
+        self.tabWidget.addTab(self.tabStudyPlan, "")
+        self.horizontalLayout_3.addWidget(self.tabWidget)
         self.verticalLayout.addLayout(self.horizontalLayout_3)
 
         self.retranslateUi(ReadabilityDialog)
+        self.tabWidget.setCurrentIndex(1)
         QtCore.QMetaObject.connectSlotsByName(ReadabilityDialog)
 
     def retranslateUi(self, ReadabilityDialog):
@@ -190,6 +234,7 @@ class Ui_ReadabilityDialog(object):
         self.inputDirectoryLabel.setText(_translate("ReadabilityDialog", "Input Directory"))
         self.inputPathButton.setText(_translate("ReadabilityDialog", "..."))
         self.dictionaryLabel.setText(_translate("ReadabilityDialog", "Morphemizer:"))
+        self.minFrequencyLabel.setText(_translate("ReadabilityDialog", "Minimum Master Frequency"))
         self.targetLabel.setText(_translate("ReadabilityDialog", "Target %"))
         self.analyzeButton.setText(_translate("ReadabilityDialog", "Analyze!"))
         self.closeButton.setText(_translate("ReadabilityDialog", "Close"))
@@ -205,4 +250,8 @@ class Ui_ReadabilityDialog(object):
         self.wordReportCheckBox.setText(_translate("ReadabilityDialog", "Word Report"))
         self.studyPlanCheckBox.setText(_translate("ReadabilityDialog", "Target Study Plan"))
         self.frequencyListCheckBox.setText(_translate("ReadabilityDialog", "Frequency List"))
+        self.tabWidget.setTabText(self.tabWidget.indexOf(self.tabOutputLog), _translate("ReadabilityDialog", "Output Log"))
+        self.tabWidget.setTabText(self.tabWidget.indexOf(self.tabReadabilityReport), _translate("ReadabilityDialog", "Readability Report"))
+        self.tabWidget.setTabText(self.tabWidget.indexOf(self.tabStudyPlan), _translate("ReadabilityDialog", "Study Plan"))
 from .UI import MorphemizerComboBox
+from .customTableWidget import CustomTableWidget


### PR DESCRIPTION
* Moved various options to cfg so they can be saved per profile and don't require editing config.py.
* New parsing options that primarily will work for the Japanese Mecab parser:
  - Option to ignore contents inside（ ）round brackets.
  - Option to ignore grammar definitions.
  - Option to treat proper nouns (people & place names) as already known in Japanese text.
* New "Minimum Master Frequency" option.
* New Table based UI features in Readability Analyzer.
* New morpheme score function in Readability Analyzer.