### PR TITLE
add GitHub Workflows

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,42 @@
+name: Lint and Test
+
+on: [push]
+
+jobs:
+  build:
+
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        python_version: ['3.6', '3.7', '3.8']
+        os: [ubuntu-latest, macOS-latest, windows-latest]
+        anki: ['2.1.16']
+    steps:
+    - uses: actions/checkout@v1
+    - name: Set up Python
+      uses: actions/setup-python@v1
+      with:
+        python-version:  ${{ matrix.python_version }}
+    - name: Install wget
+      run: choco install wget
+      if: runner.os == 'Windows'
+    - name: Install dependencies
+      shell: bash
+      run: |
+        python -m pip install --upgrade pip
+        pip install pylint
+        pip install PyQt5
+        wget --quiet https://github.com/ankitects/anki/archive/${{ matrix.anki }}.zip
+        unzip ${{ matrix.anki }}.zip
+    - name: Lint
+      shell: bash
+      run: |
+        export PYTHONPATH=./anki-${{ matrix.anki }}
+        pylint . morph test
+    - name: Test
+      shell: bash
+      run: |
+        export QT_QPA_PLATFORM=minimal
+        export PYTHONPATH=./anki-${{ matrix.anki }}
+        python test.py
+

--- a/morph/cli.py
+++ b/morph/cli.py
@@ -125,7 +125,7 @@ def cmd_count(args):
 def fix_sigpipe():
     """Set this process to exit quietly on SIGPIPE, like a good shell-pipeline citizen."""
     # For context, see e.g. https://stevereads.com/2015/09/25/python-sigpipe/.
-    signal.signal(signal.SIGPIPE, signal.SIG_DFL)
+    signal.signal(signal.SIGPIPE, signal.SIG_DFL)  # pylint: disable=E1101 # Windows doesn't have these signals
 
 
 def main():


### PR DESCRIPTION
Instead of Travis-CI we can use GitHub Actions.
This PR add configuration to run tests and pylint on a matrix of:
 * 3 python versions (3.6, 3.7, 3.8)
 * 3 OS (Ubuntu, Mac, Windows)
 * 1 Anki version

I had to skip one pylint error only happening in Windows.