### PR TITLE
Ignore simple spaces in the Japanese Mecab Morphemizer.

### DIFF
--- a/morph/morphemizer.py
+++ b/morph/morphemizer.py
@@ -52,6 +52,8 @@ def getMorphemizerByName(name):
 # Mecab Morphemizer
 ####################################################################################################
 
+space_char_regex = re.compile(' ')
+
 class MecabMorphemizer(Morphemizer):
     """
     Because in japanese there are no spaces to differentiate between morphemes,
@@ -59,6 +61,10 @@ class MecabMorphemizer(Morphemizer):
     """
 
     def getMorphemesFromExpr(self, expression):
+        # Remove simple spaces that could be added by other add-ons and break the parsing.
+        if space_char_regex.search(expression):
+            expression = space_char_regex.sub('', expression)
+
         return getMorphemesMecab(expression)
 
     def getDescription(self):


### PR DESCRIPTION
Add-ons such as MIA Japanese insert spaces (ASCII code 0x20) to mark
certain boundaries.  Those spaces can lead to incorrect parsing by
Mecab.  This change strips those spaces spaces, but doesn't affect
full-width spaces that may appear normally in Japanese script.