### PR TITLE
Add Vietnamese support using pyvi

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -28,7 +28,7 @@ jobs:
         else
           source pyenv/bin/activate
         fi
-        python -m pip install aqt==${{ matrix.anki }} anki==${{ matrix.anki }} pyqtwebengine pylint
+        python -m pip install aqt==${{ matrix.anki }} anki==${{ matrix.anki }} pyqtwebengine pylint pyvi
     - name: Lint
       shell: bash
       run: |

--- a/README.md
+++ b/README.md
@@ -30,6 +30,17 @@ MorphMan supports the following languages:
 - **Japanese**: You must additionally install the _[Japanese Support](https://ankiweb.net/shared/info/3918629684)_ Anki addon
 - **Chinese**: For Anki 2.0, please use [Jieba-Morph](https://github.com/NinKenDo64/Jieba-Morph). Chinese is included in Morphman for Anki 2.1
 - **CJK Characters**: Morphemizer that splits sentence into characters and filters for Chinese-Japanese-Korean logographic/idiographic characters.
+- **Vietnamese**: You must run Anki from source and install [pyvi](https://github.com/trungtv/pyvi) into its virtualenv:
+    - `git clone https://github.com/ankitects/anki.git`
+    - `cd anki`
+    - `make develop`
+        - Make sure you have the dependencies listed in anki/README.development
+    - `source pyenv/bin/activate`
+    - pip install pyvi
+
+    Then run Anki
+    - `./run`
+
 - more languages can be added on request if morpheme-splitting-tools are available for it
 
 See Matt VS Japan's [video tutorial](https://www.youtube.com/watch?v=dVReg8_XnyA)

--- a/morph/cli.py
+++ b/morph/cli.py
@@ -7,7 +7,7 @@ import sys
 from collections import Counter
 
 from .morphemes import MorphDb
-from .morphemizer import SpaceMorphemizer, MecabMorphemizer, CjkCharMorphemizer, JiebaMorphemizer
+from .morphemizer import SpaceMorphemizer, MecabMorphemizer, CjkCharMorphemizer, JiebaMorphemizer, VietnameseMorphemizer
 
 
 # hack: typing is compile time anyway, so, nothing bad happens if it fails, the try is to support anki < 2.1.16
@@ -88,6 +88,7 @@ MIZERS = {
     'mecab': MecabMorphemizer(),
     'cjkchar': CjkCharMorphemizer(),
     'jieba': JiebaMorphemizer(),
+    'vietnamese': VietnameseMorphemizer(),
 }
 
 

--- a/test/test_vietnamese_morphemizer.py
+++ b/test/test_vietnamese_morphemizer.py
@@ -1,0 +1,34 @@
+﻿from morph.morphemizer import getMorphemizerByName
+import unittest
+
+class TestVietnameseMorphemizer(unittest.TestCase):
+    def setUp(self):
+        self.morphemizer = getMorphemizerByName("VietnameseMorphemizer")
+
+    def test_morpheme_generation(self):
+        if self.morphemizer is not None:
+            sentence_1 = ("Trăm năm trong cõi người ta,"
+                          " Chữ tài chữ mệnh khéo là ghét nhau."
+                          " Trải qua một cuộc bể dâu,"
+                          " Những điều trông thấy mà đau đớn lòng.")
+
+            case_1 = ["trăm năm", "trong", "cõi", "người ta", "chữ", "tài", "chữ", "mệnh",
+                      "khéo", "là", "ghét", "nhau", "trải", "qua", "một", "cuộc", "bể dâu",
+                      "những", "điều", "trông", "thấy", "mà", "đau đớn", "lòng"]
+
+            sentence_2 = "Mặt Trời"
+
+            case_2 = ["mặt trời"]
+
+            for idx, m in enumerate(self.morphemizer.getMorphemesFromExpr(sentence_1)):
+                self.assertEqual(m.base, case_1[idx])
+
+            for idx, m in enumerate(self.morphemizer.getMorphemesFromExpr(sentence_2)):
+                self.assertEqual(m.base, case_2[idx])
+
+        else:
+            print('\npyvi is not installed, skipping Vietnamese tests')
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Hi!

Vietnamese doesn't separate words with spaces like most other languages that use the Latin alphabet[1], so the current spaces morphemizer is unsuitable.

[1] Fun read https://www.tandfonline.com/doi/pdf/10.1080/00437956.1963.11659787

I wasn't able to find a small library that would do word segmentation for Vietnamese like Jieba does for Chinese. To bundle pyvi in-code like Jieba has been bundled would require bundling many larger dependencies (e.g. Numpy).

So, if merged like this, it's unfortunately a burden on the end user to get the Vietnamese support working. On the other hand, if they don't want it, it won't appear or impact their usage.

If this gets included I'll look into packaging pyvi and it's dependencies as a separate addon like has been done for Mecab, licences permitting. That would make the installation more straight-forward and avoid forcing use of the source version of Anki.