### PR TITLE
make compatible with new DBProxy.executemany

### DIFF
--- a/morph/main.py
+++ b/morph/main.py
@@ -389,11 +389,11 @@ def updateNotes(allDb):
             csum = fieldChecksum(fs[0])
             sfld = stripHTML(fs[getSortFieldIndex(mid)])
             ds.append(
-                {'now': now, 'tags': tags_, 'flds': flds_, 'sfld': sfld, 'csum': csum, 'usn': mw.col.usn(), 'nid': nid})
+                (tags_, flds_, sfld, csum, now, mw.col.usn(), nid))
 
     mw.progress.update(label='Updating anki database...')
     mw.col.db.executemany(
-        'update notes set tags=:tags, flds=:flds, sfld=:sfld, csum=:csum, mod=:now, usn=:usn where id=:nid', ds)
+        'update notes set tags=?, flds=?, sfld=?, csum=?, mod=?, usn=? where id=?', ds)
 
     # Now reorder new cards based on MMI
     mw.progress.update(label='Updating new card ordering...')
@@ -406,11 +406,11 @@ def updateNotes(allDb):
         if nid in nid2mmi:  # owise it was disabled
             due_ = nid2mmi[nid]
             if due != due_:  # only update cards that have changed
-                ds.append({'now': now, 'due': due_,
-                           'usn': mw.col.usn(), 'cid': cid})
+                ds.append((due_, now,
+                           mw.col.usn(), cid))
 
     mw.col.db.executemany(
-        'update cards set due=:due, mod=:now, usn=:usn where id=:cid', ds)
+        'update cards set due=?, mod=?, usn=? where id=?', ds)
     mw.reset()
 
     printf('Updated notes in %f sec' % (time.time() - t_0))


### PR DESCRIPTION
Anki internal restructuring means that old sqlite database code doesn't work anymore (see #116).

I manually checked that this code works on Anki versions 2.1.22 and 2.1.26. 