### PR TITLE
Fix #100 regex for round brackets

### DIFF
--- a/morph/morphemes.py
+++ b/morph/morphemes.py
@@ -122,7 +122,7 @@ class MorphDBUnpickler(pickle.Unpickler):
         return pickle.Unpickler.find_class(self, cmodule, cname)
 
 square_brackets_regex = re.compile(r'\[[^\]]*\]')
-round_brackets_regex = re.compile(r'（[^）]+）')
+round_brackets_regex = re.compile(r'\([^)]*\)')
 
 def getMorphemes(morphemizer, expression, note_tags=None):
     if cfg('Option_IgnoreBracketContents'):


### PR DESCRIPTION
This change fixes #100 where the option "Ignore everything contained in () Brackets" did not work
After changing the regex it now works.