### PR TITLE
Fix learn now crash issue #83

### DIFF
--- a/morph/browser/learnNow.py
+++ b/morph/browser/learnNow.py
@@ -18,8 +18,10 @@ def per(st, c):
 def post(st):
     for c in st['cards']:
         mw.reviewer.cardQueue.append(c)
-    st['browser'].close()
-    infoMsg("")  # Prevents an AttributeError directly above
+
+    browser = st['browser']
+    mw.progress.timer(100, lambda: browser.close(), False)
+
     tooltip(_('Immediately reviewing {} cards'.format(len(st['cards']))))
     return st
 


### PR DESCRIPTION
There seem to be pending window messages queued when the window is
closed in the learn now handler. By delaying the close request with
the timer those messages can be processed after the handler returns
and the window is closed without issue.