### PR TITLE
Skip Notes Instead of Cards

### DIFF
--- a/morph/newMorphHelper.py
+++ b/morph/newMorphHelper.py
@@ -130,13 +130,15 @@ def my_getNewCard(self, _old):
         is_fresh_vocab = note.hasTag(cfg('Tag_Fresh'))
         is_already_known = note.hasTag(cfg('Tag_AlreadyKnown'))
 
+        no_cards_learned_yet = mw.col.db.scalar('select count() from cards where nid = :nid and queue > 0', nid=note.id) == 0
+
         skip_comprehension = cfg('Option_SkipComprehensionCards')
         skip_fresh = cfg('Option_SkipFreshVocabCards')
         skip_focus_morph_seen_today = cfg('Option_SkipFocusMorphSeenToday')
 
         skip_conditions = [
             is_comprehension_card and skip_comprehension,
-            is_fresh_vocab and skip_fresh,
+            is_fresh_vocab and skip_fresh and no_cards_learned_yet,
             is_already_known,  # the user requested that the vocabulary does not have to be shown
             focus_morph in seenMorphs and skip_focus_morph_seen_today,  # we already learned that/saw that today
         ]


### PR DESCRIPTION
Fixes #106. 

Cards should only be skipped if all the cards on that note are also skipped. If one card is learned, the other cards should be too. See the above issue for examples.

This is a simple fix, that is far from perfect. Though @AtilioA has also tested it, so it does work at least.

Possible Improvements:
 * Add a hefty bonus to each card of a note with any learned cards. 
  This will keep the other cards from falling down into the queue after the morph has been learned. I do not believe I have experienced this, but I can see it is a possibility.
 * Make this a config option.
  I personally cannot see a reason why someone would want to skip subsequent card types, surely they'd just remove the card type they never study? Though if others want it I could add a togglable option for this.

All feedback welcome :+1: 