### PR TITLE
Make Recalc faster

### DIFF
--- a/morph/preferences.py
+++ b/morph/preferences.py
@@ -2,27 +2,32 @@
 import importlib
 from aqt import mw
 
+config_py = None
+
+preferences_cache = None
 
 def init_preferences():
     _init_config_py()
     _init_anki_json_config()
+
+    global preferences_cache
+    preferences_cache = _jsonConfig()
 
 
 def get_preference(key, model_id=None, deck_id=None):
     try:
         return _get_config_py_preference(key, model_id, deck_id)
     except KeyError:
-        return _get_anki_json_config(key)
+        return preferences_cache.get(key)
 
 
 def update_preferences(jcfg):
     original = mw.col.conf['addons']['morphman'].copy()
     mw.col.conf['addons']['morphman'].update(jcfg)
-    if not mw.col.conf['addons']['morphman'] == original:
+    if mw.col.conf['addons']['morphman'] != original:
         mw.col.setMod()
-
-
-config_py = None
+        global preferences_cache
+        preferences_cache = mw.col.conf['addons']['morphman']
 
 
 def _init_config_py():
@@ -145,7 +150,7 @@ def _jsonConfig():
 
 
 def _get_anki_json_config(key):
-    return _jsonConfig().get(key)
+    return preferences_cache.get(key)
 
 
 def _add_missing_json_config():

--- a/morph/preferences.py
+++ b/morph/preferences.py
@@ -1,5 +1,7 @@
 # -*- coding: utf-8 -*-
+import copy
 import importlib
+
 from aqt import mw
 
 config_py = None
@@ -22,10 +24,13 @@ def get_preference(key, model_id=None, deck_id=None):
 
 
 def update_preferences(jcfg):
-    original = mw.col.conf['addons']['morphman'].copy()
-    mw.col.conf['addons']['morphman'].update(jcfg)
-    if mw.col.conf['addons']['morphman'] != original:
+    original_prefs = copy.deepcopy(mw.col.conf['addons']['morphman'])
+    new_prefs = copy.deepcopy(original_prefs)
+    new_prefs.update(jcfg)
+    if new_prefs != original_prefs:
+        mw.col.conf['addons']['morphman'] = new_prefs
         mw.col.setMod()
+
         global preferences_cache
         preferences_cache = mw.col.conf['addons']['morphman']
 


### PR DESCRIPTION
I profiled the Morphman Recalc action and noticed, that over 90% of the time was spent getting preferences from the Anki ConfigManager. I introduced a cache and could reduce the Recalc duration from 160 seconds to 13.