### PR TITLE
Updates pylint config for Anki 2.1.26 (README & Github Workflow updates)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,7 +10,7 @@ jobs:
       matrix:
         python_version: ['3.6', '3.7', '3.8']
         os: [ubuntu-latest, macOS-latest, windows-latest]
-        anki: ['2.1.16']
+        anki: ['2.1.26']
     steps:
     - uses: actions/checkout@v1
     - name: Set up Python
@@ -31,12 +31,12 @@ jobs:
     - name: Lint
       shell: bash
       run: |
-        export PYTHONPATH=./anki-${{ matrix.anki }}
+        export PYTHONPATH=./anki-${{ matrix.anki }}/pylib:./anki-${{ matrix.anki }}/qt:./
         pylint . morph test
     - name: Test
       shell: bash
       run: |
         export QT_QPA_PLATFORM=minimal
-        export PYTHONPATH=./anki-${{ matrix.anki }}
+        export PYTHONPATH=./anki-${{ matrix.anki }}/pylib:./anki-${{ matrix.anki }}/qt:./
         python test.py
 

--- a/README.md
+++ b/README.md
@@ -42,9 +42,9 @@ See the [MorphMan wiki](https://github.com/kaegi/MorphMan/wiki) for more informa
   - pip install pylint
   - pip install PyQt5
   - install Anki source code, for example:
-      - wget https://github.com/dae/anki/archive/2.1.16.tar.gz
-      - tar -xzvf 2.1.16.tar.gz
-      - export PYTHONPATH=./anki-2.1.16
+      - wget https://github.com/dae/anki/archive/2.1.26.tar.gz
+      - tar -xzvf 2.1.26.tar.gz
+      - export PYTHONPATH=./anki-2.1.26/pylib:./anki-2.1.26/qt:./
 - Run tests: `python test.py`
 - Build Qt Developer UI with `python scripts/build_ui.py`
 - Install git commit hook to run tests and pylint


### PR DESCRIPTION
Anki's directory structure changed, and the `PYTHONPATH` suggestion in the `README.md` no longer works since Anki 2.1.17

My changes corrects this, plus suggests adding the root directory to `PYTHONPATH` to allow `pylint <directory>` to be able to access all libraries accessible from the root project

I've tested this with Anki 2.1.26 (stable) and access to libraries works fine. I do not been able to test against the latest stable Anki 2.1.35, as it's currently not in the Arch repos, so any help would be appreciated.