### PR TITLE
Merging changes to update to anki 2.1.35

### DIFF
--- a/docs/new-features.org
+++ b/docs/new-features.org
@@ -9,10 +9,12 @@
 #+OPTIONS: ^:nil
 
 
+There are several new features in morphman, which are documented below:
+
 * Sqlite support
 
-A new option called saveSQLite has been added.. If True, a sqlite database called morphman.sqlite is created.
-The default of this option is True
+A new option called saveSQLite has been added. If True, a sqlite database called morphman.sqlite is created.  The
+default of this option is True
 
 The schema of this database is straighforward:
 
@@ -49,26 +51,70 @@ CREATE TABLE locations (
 #+end_src
 
 
-* dump_db (Completed)
+* dump_db.py
 
-Dump the morphman pickled database in a readable format. See scripts/dump_db.py
+the script scripts/dump_db.py can be used to dump the pickled databases (.db) 
+from the command line. Simply run 
+
+#+begin_src bash
+python3 scripts/dump_db.py <picked-database-file>
+#+end_src
+
+The output is straighforward:
+
+For every moprh, it prints its information and the noteid, fieldname, fieldvalue, maturity (in days), guid and the weight.
+See the documentation of Location (under sqlite3) above
+
+#+begin_example
+norm	base	inflected	reading	pos	subpos
+が	が	が	ガ	助詞	格助詞
+	 	1536650898064;sentenceJPnuke;45;DJgfwS>YL^;1
+	 	1536651281457;sentenceJp;22;o!aP/}@6+5;1
+	 	1536650897940;sentenceJp;259;d>&JX6S_Bd;1
+	 	1487630686913;Expression;277;v-,8t@ro!L;1
+	 	1487630686856;Expression;168;mX1IuArU9S;1
+	 	1489462758391;Expression;103;fd[asSdN3~;1
+	 	1487630687241;Expression;320;gTy?mxI5y];1
+	 	1536651300085;sentenceJp;22;C.!^yST7m8;1
+	 	1536651299859;sentenceJp;200;CcH+l<Y_td;1
+	 	1487630686818;Expression;138;q^h7dzq%1n;1
+	 	1489462776809;Expression;114;g@A7}LZ#;&;1
+	 	1536651300164;sentenceJp;22;fnM.#k3}En;1
+	 	1536650897908;sentenceJp;147;i[{pI;:U>|;1
+	 	1536650898337;sentenceJp;23;ez^L$2ON)M;1
+	 	1489462758327;Expression;198;lQ@.k1)U[8;1
+	 	1487630687083;Expression;288;nD){h(39!I;1
+	 	1489462791313;Expression;54;IR)(c(9dd6;1
+	 	1487630686948;Expression;193;kux^L#r]R4;1
+#+end_example
 
 
+* Display the name of the mecab dictionary currently in use 
 
-* Display the name of the mecab dictionary currently in use
+The readability report will include a line describing the name of the Mecab being used.
 
-This is one of the main challenges of configuring a different mecab: it is hard to know which one is Morphman actually using
+For example, this is an excerpt from the Output Log of the readability analyzer:
 
-* Do not consider leech suspended cards in the counts
+#+begin_example
+...
+Million Yen Women-S1_E12-Emotions_ja.srt	561	487	86.81	1851	1775	95.89	2.97	82.12	11.92
+
+Used morphemizer: Japanese MecabUnidic
+
+[Saving word report to '/Users/dmg/Library/Application Support/Anki2/User 1/dbs/word_freq_report.txt'...]
+...
+#+end_example
+
+
+* Support to ignore narrow parentheses
+
+There is a new option called Option_IgnoreSlimRoundBracketContents, defaults to False
+
+If enabled, text between narrow parentheses () will be ignored. There is a different option for wide (UNICODE)
+parentheses （）called Option_IgnoreRoundBracketContents
+
+
+* Do not consider leech suspended cards in the counts (todo)
 
 I would like morphman to ignore cards that are leeches and are suspended. In other words, if the card is a leech and got suspended, then it should not count towards the morphs I know.
 
-
-* Update to new API
-
-- updated sqlite calls to remove named parameters via a dictionary
-- updated access to new preferences API
-
-* Other minor changes
-
-- added support to ignore also narrow () (in addition to wide parentheses)

--- a/docs/new-features.org
+++ b/docs/new-features.org
@@ -9,11 +9,9 @@
 #+OPTIONS: ^:nil
 
 
-This is my attemp to add some features that I would like to see in morphman:
+* Sqlite support
 
-* Sqlite support (Completed)
-
-I want to be able to access morphman data using sqlite. I have created an option called 'saveSQLite'. If True, a sqlite database called morphman.sqlite is created.
+A new option called saveSQLite has been added.. If True, a sqlite database called morphman.sqlite is created.
 The default of this option is True
 
 The schema of this database is straighforward:

--- a/docs/plan.org
+++ b/docs/plan.org
@@ -23,7 +23,15 @@ The schema of this database is straighforward:
 this is the table that contains the morphs. The "inflected" field is the actual word.
 
 #+begin_src sql
-CREATE TABLE morphs (morphid, norm, base, inflected, read, pos, subpos, primary key (morphid));
+CREATE TABLE morphs (
+      morphid, 
+      norm, 
+      base, 
+      inflected, 
+      read, 
+      pos, 
+      subpos, 
+      primary key (morphid));
 #+end_src
 
 ** location
@@ -35,13 +43,19 @@ Most fields are self-explanatory. maturity is days to next review (0 for non-rev
 guid (I don't know), and weight ... mmmm, it is 1 in all cases. I guess it is not used
 
 #+begin_src sql
-CREATE TABLE locations (morphid, noteid, field, fieldvalue, maturity, guid, weight, primary key (morphid, noteid, field), foreign key (morphid) references morphs);
+CREATE TABLE locations (
+    morphid, noteid, field, fieldvalue, maturity, guid, weight, 
+    primary key (morphid, noteid, field), 
+    foreign key (morphid) references morphs
+);
 #+end_src
 
 
 * dump_db (Completed)
 
 Dump the morphman pickled database in a readable format. See scripts/dump_db.py
+
+
 
 * Display the name of the mecab dictionary currently in use
 
@@ -51,3 +65,12 @@ This is one of the main challenges of configuring a different mecab: it is hard 
 
 I would like morphman to ignore cards that are leeches and are suspended. In other words, if the card is a leech and got suspended, then it should not count towards the morphs I know.
 
+
+* Update to new API
+
+- updated sqlite calls to remove named parameters via a dictionary
+- updated access to new preferences API
+
+* Other minor changes
+
+- added support to ignore also narrow () (in addition to wide parentheses)

--- a/docs/plan.org
+++ b/docs/plan.org
@@ -1,0 +1,53 @@
+#+STARTUP: showall
+#+STARTUP: lognotestate
+#+TAGS: research(r) uvic(u) today(y) todo(t) cooking(c)
+#+SEQ_TODO: TODO(t) STARTED(s) DEFERRED(r) CANCELLED(c) | WAITING(w) DELEGATED(d) APPT(a) DONE(d)
+#+DRAWERS: HIDDEN STATE
+#+ARCHIVE: %s_done::
+#+TITLE: Improving morphman
+#+CATEGORY: 
+#+OPTIONS: ^:nil
+
+
+This is my attemp to add some features that I would like to see in morphman:
+
+* Sqlite support (Completed)
+
+I want to be able to access morphman data using sqlite. I have created an option called 'saveSQLite'. If True, a sqlite database called morphman.sqlite is created.
+The default of this option is True
+
+The schema of this database is straighforward:
+
+** morphs
+
+this is the table that contains the morphs. The "inflected" field is the actual word.
+
+#+begin_src sql
+CREATE TABLE morphs (morphid, norm, base, inflected, read, pos, subpos, primary key (morphid));
+#+end_src
+
+** location
+
+This are the notes where a given morph is located, and some information about it (some is redundant, such as the actual value of the field, which can be extracted from
+anki's database, but morphan saves it, so it is saved). 
+
+Most fields are self-explanatory. maturity is days to next review (0 for non-reviewed)... mmm, maybe i am missing some words if the review is in less than 1 day... then... what if it is the first day or reviews...
+guid (I don't know), and weight ... mmmm, it is 1 in all cases. I guess it is not used
+
+#+begin_src sql
+CREATE TABLE locations (morphid, noteid, field, fieldvalue, maturity, guid, weight, primary key (morphid, noteid, field), foreign key (morphid) references morphs);
+#+end_src
+
+
+* dump_db (Completed)
+
+Dump the morphman pickled database in a readable format. See scripts/dump_db.py
+
+* Display the name of the mecab dictionary currently in use
+
+This is one of the main challenges of configuring a different mecab: it is hard to know which one is Morphman actually using
+
+* Do not consider leech suspended cards in the counts
+
+I would like morphman to ignore cards that are leeches and are suspended. In other words, if the card is a leech and got suspended, then it should not count towards the morphs I know.
+

--- a/morph/config.py
+++ b/morph/config.py
@@ -94,6 +94,12 @@ default = {
     'new card merged fill': False,
     # k+1 by default. this mostly is to boost performance of 'next new card feature'
     'new card merged fill min due': 100000,
+
+    # round brackets
+    #Option_IgnoreSlimRoundBracketContents : False,
+    #Option_IgnoreRoundBracketContents : False,
+    #Option_IgnoreBracketContents : False,
+
 }
 # Can override anything. 3rd priority
 profile_overrides = {

--- a/morph/config.py
+++ b/morph/config.py
@@ -52,7 +52,7 @@ default = {
     # whether to load existing all.db when recalculating or create one from scratch
     'loadAllDb': True,
     'saveDbs': True,     # whether to save all.db, known.db, mature.db, and seen.db
-
+    'saveSQLite': False,  # save the data also in an sqlite database
     # only these can have model overrides
     # whether to modify card Due times based on MorphManIndex. does nothing if relevant notes aren't enabled
     'set due based on mmi': True,

--- a/morph/main.py
+++ b/morph/main.py
@@ -105,7 +105,7 @@ def mkAllDb(all_db=None):
         N_enabled_notes += 1
 
         mats = [(0.5 if ivl == 0 and ctype == 1 else ivl) for ivl, ctype in
-                db.execute('select ivl, type from cards where nid = :nid', nid=nid)]
+                db.execute('select ivl, type from cards where nid = ?', nid)]
         if C('ignore maturity'):
             mats = [0] * len(mats)
         ts, alreadyKnownTag = TAG.split(tags), cfg('Tag_AlreadyKnown')

--- a/morph/mecab_wrapper.py
+++ b/morph/mecab_wrapper.py
@@ -4,6 +4,8 @@ import importlib.util
 import re
 import subprocess
 import sys
+from .util import printf
+
 
 from .morphemes import Morpheme
 from .util_external import memoize
@@ -38,12 +40,17 @@ is_unidic = True
 
 kanji = r'[㐀-䶵一-鿋豈-頻]'
 
+mecab_source = ""
 
 def extract_unicode_block(unicode_block, string):
     """ extracts and returns all texts from a unicode block from string argument.
         Note that you must use the unicode blocks defined above, or patterns of similar form """
     return re.findall(unicode_block, string)
 
+
+def getMecabIdentity():
+    # identify the mecab being used
+    return mecab_source
 
 def getMorpheme(parts):
     global is_unidic
@@ -147,6 +154,8 @@ def mecab():  # IO MecabProc
     instance is needed.  That's why this function is memoized.
     """
 
+    global mecab_source # make it global so we can query it later
+
     if sys.platform.startswith('win'):
         si = subprocess.STARTUPINFO()
         try:
@@ -164,14 +173,14 @@ def mecab():  # IO MecabProc
     if importlib.util.find_spec('MecabUnidic'):
         try:
             reading = importlib.import_module('MecabUnidic.reading')
-            mecab_source = 'MecabUnidic'
+            mecab_source = 'MecabUnidic from addon MecabUnidic'
         except ModuleNotFoundError:
             pass
     
     if importlib.util.find_spec('13462835'):
         try:
             reading = importlib.import_module('13462835.reading')
-            mecab_source = 'MecabUnidic'
+            mecab_source = 'MecabUnidic from addon 13462835'
         except ModuleNotFoundError:
             pass
 
@@ -179,7 +188,7 @@ def mecab():  # IO MecabProc
     if (not reading) and importlib.util.find_spec('3918629684'):
         try:
             reading = importlib.import_module('3918629684.reading')
-            mecab_source = 'Japanese Support'
+            mecab_source = 'Japanese Support from addon 3918629684'
         except ModuleNotFoundError:
             pass
 
@@ -187,14 +196,14 @@ def mecab():  # IO MecabProc
     if (not reading) and importlib.util.find_spec('MIAJapaneseSupport'):
         try:
             reading = importlib.import_module('MIAJapaneseSupport.reading')
-            mecab_source = 'MIAJapaneseSupport'
+            mecab_source = 'MIAJapaneseSupport from addon MIAJapaneseSupport'
         except ModuleNotFoundError:
             pass
-    # 4nd priority - MIAJapaneseSupport via Anki code (278530045)
+    # 4nd priority - MigakuJapaneseSupport via Anki code (278530045)
     if (not reading) and importlib.util.find_spec('278530045'):
         try:
             reading = importlib.import_module('278530045.reading')
-            mecab_source = '278530045'
+            mecab_source = 'Migaku Japanese support from addon 278530045'
         except ModuleNotFoundError:
             pass
 
@@ -221,6 +230,7 @@ def mecab():  # IO MecabProc
     m = reading.MecabController()
     m.setup()
     # m.mecabCmd[1:4] are assumed to be the format arguments.
+    printf('Using morphman: [%s] with command line [%s]' % (mecab_source, m.mecabCmd))
 
     return spawnMecab(m.mecabCmd[:1] + m.mecabCmd[4:], si), mecab_source
 

--- a/morph/morphemes.py
+++ b/morph/morphemes.py
@@ -125,8 +125,12 @@ class MorphDBUnpickler(pickle.Unpickler):
             return globals()[cname]
         return pickle.Unpickler.find_class(self, cmodule, cname)
 
+# regex to remove brackets
 square_brackets_regex = re.compile(r'\[[^\]]*\]')
-round_brackets_regex = re.compile(r'（[^）]+）')
+# regex to remove wide (UNICODE) parentheses
+round_brackets_regex       = re.compile(r'（[^）]*）') 
+# regex to remove slim () parentheses
+slim_round_brackets_regexp = re.compile(r'\([^\)]*\)')
 
 def getMorphemes(morphemizer, expression, note_tags=None):
     if cfg('Option_IgnoreBracketContents'):
@@ -135,6 +139,9 @@ def getMorphemes(morphemizer, expression, note_tags=None):
     if cfg('Option_IgnoreRoundBracketContents'):
         if round_brackets_regex.search(expression):
             expression = round_brackets_regex.sub('', expression)
+    if cfg('Option_IgnoreSlimRoundBracketContents'):
+        if slim_round_brackets_regex.search(expression):
+            expression = slim_round_brackets_regex.sub('', expression)
 
     # go through all replacement rules and search if a rule (which dictates a string to morpheme conversion) can be
     # applied

--- a/morph/morphemes.py
+++ b/morph/morphemes.py
@@ -3,6 +3,10 @@ import codecs
 import gzip
 import os
 import pickle as pickle
+import sqlite3
+from .util import printf
+
+
 from abc import ABC, abstractmethod
 
 import re
@@ -235,7 +239,7 @@ def altIncludesMorpheme(m, alt):
 
     return m.norm == alt.norm and (m.base == alt.base or m.base_kanji() <= alt.base_kanji())
 
-
+    
 class MorphDb:
     @staticmethod
     def mergeFiles(aPath, bPath, destPath=None,
@@ -295,6 +299,8 @@ class MorphDb:
         f = gzip.open(path, 'wb')
         pickle.dump(self.db, f, -1)
         f.close()
+        if cfg('saveSQLite'):
+            save_db(self.db, path)
 
     def load(self, path):  # FilePath -> m ()
         f = gzip.open(path)
@@ -441,3 +447,134 @@ class MorphDb:
                            for k, v in self.posBreakdown.items())
         return 'Total normalized morphemes: %d\nTotal variations: %d\nBy part of speech:\n%s' % (
             self.kCount, self.vCount, posStr)
+
+
+# sqlite code
+
+def connect_db(path):
+    conn = sqlite3.connect(path)
+    return conn
+
+def drop_table(cur, name):
+    sql = "drop table if exists %s;"%(name);
+    cur.execute(sql)
+
+def create_table(cur, name, fields, extra = ""):
+    sql = "create table %s (%s%s);"%(name,fields, extra)
+    cur.execute(sql)
+
+# helper functions to convert morphman objectsi into sql tuples
+def transcode_item(item):
+    return (item.norm, item.base, item.inflected, item.read, item.pos, item.subPos)
+
+def transcode_location(loc):
+    return (loc.noteId, loc.fieldName, loc.fieldValue, loc.maturity, loc.guid, loc.weight)
+    
+def save_db_all_morphs(cur, db, tname):
+
+    # we cannot use the name 'all' for a table
+    # since it is a reserved word in sql
+    if tname == 'all':
+        # used 'morphs' instead
+        tname = 'morphs'
+
+    # fields  of table to be created
+    fields = "morphid, norm, base, inflected, read, pos, subpos"
+
+    drop_table(cur, tname);
+
+    create_table(cur, tname,fields, ", primary key (morphid)");
+
+    def transcode_item_pair(el):
+        # el is a pair: <the morphid (an int), morph object>
+        # this is a helper function for the map below
+        item = el[1]
+        return (el[0],)+ transcode_item(item)
+
+    # convert the info in the db into list of tuples
+    tuples = map(transcode_item_pair, enumerate(db.keys()))
+
+    # insert them all at once
+    cur.executemany("INSERT INTO %s (%s) VALUES(?,?,?,?,?,?,?);"%(tname,fields), tuples)
+
+def read_db_all_morphs(cur):
+    # read the morphs as a dictionary, where the key is the morph tuple and
+    # the value is the morphid
+    # see save_db_all_morphs for the schema of the morphs relation
+    
+    cur.execute("SELECT * FROM morphs;")
+    rows = cur.fetchall()
+    forDict = map(lambda x: (x[1:], x[0]), rows)
+    return dict(forDict)
+    
+def save_db_locations(cur, db, tname='locations'):
+    # save a morphman db as a table in database
+    # it is usually faster to drop the table than delete/update the tuples
+    # in it
+    drop_table(cur, tname);
+
+    # fields for the table
+    fields = "morphid, noteid, field, fieldvalue, maturity, guid, weight"
+    create_table(cur, tname,fields,
+       ", primary key (morphid, noteid, field), foreign key (morphid) references morphs");
+
+    # we need to know the morphid of each morph
+    # so we can properly reference them in the table locations
+    # (see foreign key constraint in the table create above)
+    # in theory we have this info, but this mades the code
+    # simpler and less error prone and it the time penalty
+    # seems to be minimal
+    
+    # morphs is a dictionary that maps
+    #  transcode_item(morph) to its morphid (int)
+    morphs = read_db_all_morphs(cur)
+
+    # we need to convert the db of morphs into a list of tuples
+    # where the first value is the morphid (stored in the table
+    # we just created)
+    
+    # a morph might have multiple locations
+    # map each morph in db into a list [morphidlist, location info]
+    locationsLists =map(lambda x: # this is a pair of morph and list of locations
+               list(map(lambda y: (morphs[transcode_item(x[0])],)+transcode_location(y),x[1])),
+               db.items())
+
+    # flatten the list... because we have a list of lists (one list per morph)
+    tuples = [val for sublist in locationsLists for val in sublist]
+
+    cur.executemany("INSERT INTO %s (%s) VALUES(?,?,?,?,?,?,?);"%(tname,fields), tuples)
+        
+
+def save_db(db, path):
+    # assume that the directory is already created...
+    # exceptions will handle the errors
+
+    # we need to wedge this code in here, while we refactor the code...
+    # morphman stores info in a bunch of files.
+    #
+    # database with each "file" as a table
+    # so let use the basefilename of the relation as
+    tname = os.path.basename(path)
+    dirName = os.path.dirname(path)
+    # it ends with .db so cut it
+    assert (len(tname)> 3 and tname[-3:] == '.db'), "extension is no longer .db?"
+
+    # name of the morphs to save (all, known, etc.)
+    tname = tname[:-3]
+    dbName = dirName + '/morphman.sqlite'
+
+    conn = connect_db(dbName)
+    with conn:
+        cur = conn.cursor()
+        # it looks like we only need to save the "all" data
+        # the others seem to be subsets of it (based on the
+        # maturity field)
+        if (tname == 'all'):
+            # save morphs
+            save_db_all_morphs(cur, db, tname)
+            # then we need to save the locations
+            # every morph in location is guaranteed in db at this point
+            save_db_locations(cur, db)
+        conn.commit()
+
+    printf("Saved to sqlite Tname [%s] dbname [%s]"%(tname, dbName))

--- a/morph/morphemizer.py
+++ b/morph/morphemizer.py
@@ -3,7 +3,7 @@ import re
 
 from .morphemes import Morpheme
 from .deps.zhon.hanzi import characters
-from .mecab_wrapper import getMorphemesMecab
+from .mecab_wrapper import getMorphemesMecab, getMecabIdentity
 from .deps.jieba import posseg
 
 
@@ -68,7 +68,7 @@ class MecabMorphemizer(Morphemizer):
         return getMorphemesMecab(expression)
 
     def getDescription(self):
-        return 'Japanese'
+        return 'Japanese ' + getMecabIdentity()
 
 
 ####################################################################################################

--- a/morph/preferences.py
+++ b/morph/preferences.py
@@ -14,11 +14,10 @@ def get_preference(key, model_id=None, deck_id=None):
     except KeyError:
         return _get_anki_json_config(key)
 
-
 def update_preferences(jcfg):
-    original = mw.col.conf['addons']['morphman'].copy()
-    mw.col.conf['addons']['morphman'].update(jcfg)
-    if not mw.col.conf['addons']['morphman'] == original:
+    original = _jsonConfig().copy()
+    _jsonConfig().update(jcfg)
+    if not _jsonConfig() == original:
         mw.col.setMod()
 
 
@@ -138,11 +137,16 @@ def jcfg_default():
     }
 
 
-def _jsonConfig():
-    conf = mw.col.conf['addons']['morphman']
-    assert conf, 'Tried to use jcfgMods before profile loaded'
-    return conf
+# retrieving the configuration using get_config is very expensive operation
+# instead, save it 
+configData = None
 
+def _jsonConfig():
+    global configData 
+    if (configData == None):
+        configData = mw.col.get_config('addons')['morphman']
+        assert configData, 'Tried to use jcfgMods before profile loaded'
+    return configData
 
 def _get_anki_json_config(key):
     return _jsonConfig().get(key)

--- a/morph/readability.py
+++ b/morph/readability.py
@@ -408,6 +408,8 @@ class MorphMan(QDialog):
                     is_ass = os.path.splitext(file_path)[1].lower() == '.ass'
                     is_srt = os.path.splitext(file_path)[1].lower() == '.srt'
                     measure_readability(file_path, is_ass, is_srt)
+
+            self.writeOutput('\nUsed morphemizer: %s\n' % morphemizer.getDescription())
             mw.progress.finish()
         else:
             self.writeOutput('\nNo files found to process.\n')

--- a/scripts/dumb_db.py
+++ b/scripts/dumb_db.py
@@ -12,6 +12,10 @@ sys.path.insert(1, morphDir)
 
 from morphemes import Morpheme, MorphDb
 
+def show_location(loc):
+    return "\t%s;%s;%s;%s;%s"%(loc.noteId, loc.fieldName, loc.maturity, loc.guid, loc.weight)
+
+
 class Dumpster():
     def __init__(self, path=None, parent=None):
         self.db = MorphDb(path)
@@ -20,7 +24,8 @@ class Dumpster():
         print('\t'.join(['norm', 'base', 'inflected', 'reading', 'pos', 'subpos']))
         for m, ls in self.db.db.items():
             print (m.show())
-
+            for l in ls:
+                print("\t",show_location(l))
 
 if __name__ == "__main__":
     if len(sys.argv) == 2:


### PR DESCRIPTION
I have cleaned the commits. I have merge/split/reposition commits to make sure that each commit does one and only one thing. 

- updated settings to use new anki API
- added support to export morphs to sqlite3 (disabled by default)
- added optional support to ignore narrow parentheses (not available in GUI yet)
- added profiling code (disabled by default)
- print and log the name of the mecab being used

I have disabled sqlite3 support by default. It takes around 3 seconds to save my collection (20k morphs, .4M locations). This database is 54 Mbytes.