### PR TITLE
Hotfix: V2 card queue now rebuilds properly after burying cards

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -7,7 +7,6 @@ import importlib
 
 import anki.stats
 from anki import hooks
-from anki.collection import Collection
 from anki.lang import _  # TODO: deprecated?
 
 from .morph.util import *  # TODO: replace this star
@@ -44,7 +43,7 @@ def main():
     from .morph.browser import browseMorph
     from .morph.browser import alreadyKnownTagger
 
-    gui_hooks.collection_did_load.append(replace_reviewer_functions)
+    gui_hooks.profile_did_open.append(replace_reviewer_functions)
 
     # This stores the focus morphs seen today, necessary for the respective skipping option to work
     gui_hooks.reviewer_did_answer_card.append(mark_morph_seen)
@@ -82,7 +81,7 @@ def mark_morph_seen(reviewer: Reviewer, card, ease):
     reviewing_utils.mark_morph_seen(card.note())
 
 
-def replace_reviewer_functions(collection: Collection) -> None:
+def replace_reviewer_functions() -> None:
     # This skips the cards the user specified in preferences GUI
     Reviewer.nextCard = hooks.wrap(Reviewer.nextCard, reviewing_utils.my_next_card, "around")
 

--- a/__init__.py
+++ b/__init__.py
@@ -45,15 +45,15 @@ def main():
 
     gui_hooks.profile_did_open.append(replace_reviewer_functions)
 
+    # See more detailed morph stats by holding 'Shift'-key while pressing 'Stats' in toolbar
+    # TODO: maybe move it somewhere less hidden if possible? E.g.a separate toolbar button
+    gui_hooks.profile_did_open.append(add_morph_stats_to_ease_graph)
+
     # This stores the focus morphs seen today, necessary for the respective skipping option to work
     gui_hooks.reviewer_did_answer_card.append(mark_morph_seen)
 
     # Adds the 'K: V:' to the toolbar
     gui_hooks.top_toolbar_did_init_links.append(add_morph_stats_to_toolbar)
-
-    # See more detailed morph stats by holding 'Shift'-key while pressing 'Stats' in toolbar
-    # TODO: maybe move it somewhere less hidden if possible? E.g.a separate toolbar button
-    gui_hooks.stats_dialog_will_show(add_morph_stats_to_ease_graph)
 
     gui_hooks.profile_will_close.append(tear_down_actions_and_submenu)
 


### PR DESCRIPTION
After morphman skipped cards on the V2 scheduler then the queue would decrease by the number of cards skipped instead of filling the queue with new cards. The fix is basically one line. Cleaned a tiny bit of code too.